### PR TITLE
Feature Testing Library

### DIFF
--- a/pkg/providers/cluster_k3s.go
+++ b/pkg/providers/cluster_k3s.go
@@ -239,9 +239,9 @@ func (c *K8sCluster) createK3s() error {
 	err = c.kubeClient.HealthCheckPods([]string{""}, startTimeout)
 	if err != nil {
 		// fetch the logs from the container before exit
-		lr, err := c.client.ContainerLogs(id, true, true)
-		if err != nil {
-			c.log.Error("Unable to get logs from container", "error", err)
+		lr, lerr := c.client.ContainerLogs(id, true, true)
+		if lerr != nil {
+			c.log.Error("Unable to get logs from container", "error", lerr)
 		}
 
 		// copy the logs to the output

--- a/pkg/testing/blueprint_funcs.go
+++ b/pkg/testing/blueprint_funcs.go
@@ -1,0 +1,11 @@
+package testing
+
+func (cr *goDogRunner) iRunApply() error {
+	return cr.iRunApplyAtPath("")
+}
+
+func (cr *goDogRunner) iRunApplyAtPath(path string) error {
+	_, err := cr.engine.ApplyWithVariables(path, cr.config.Variables, "")
+
+	return err
+}

--- a/pkg/testing/blueprint_funcs_test.go
+++ b/pkg/testing/blueprint_funcs_test.go
@@ -1,0 +1,26 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunCallsEngineApply(t *testing.T) {
+	r, me := setupRunner(t)
+
+	err := r.Run()
+	require.NoError(t, err)
+
+	me.AssertCalled(t, "ApplyWithVariables", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestRunCallsEngineDestroy(t *testing.T) {
+	r, me := setupRunner(t)
+
+	err := r.Run()
+	require.NoError(t, err)
+
+	me.AssertCalled(t, "Destroy", "", true)
+}

--- a/pkg/testing/config.go
+++ b/pkg/testing/config.go
@@ -1,0 +1,108 @@
+package testing
+
+import (
+	"flag"
+	"os"
+	"strings"
+)
+
+var flagVariables arrayFlags
+var flagTags string
+
+func init() {
+	flag.Var(&flagVariables, "var", "")
+	flag.StringVar(&flagTags, "tags", "", "")
+}
+
+// Config allows the configuration of the test runners
+type Config struct {
+	// Specifies if resources should be created when Runner.Run() is called
+	CreateResources bool
+	// Specifies if resources should be destroyed when Runner.Run() exits
+	DestroyResources bool
+	// Log level for output [info,debug,trace]
+	LogLevel string
+	// Shipyard variables to set for the run, these variables
+	// take precedence over any set in the feature
+	Variables map[string]string
+	// Tags filter features by
+	Tags []string
+	// Path to a directory containing the features to run
+	FeaturesPath string
+}
+
+// DefaultConfig returns a Config type set to default values
+func DefaultConfig() *Config {
+	return &Config{
+		CreateResources:  true,
+		DestroyResources: true,
+		LogLevel:         "info",
+		Variables:        map[string]string{},
+		Tags:             []string{},
+		FeaturesPath:     "./",
+	}
+}
+
+// Creates a configuration from environment variables and flags
+// ConfigFromEnv creates a configuration that overrides default values
+// using the following flags or environment variables
+//
+// LogLevel can be set using the LOG_LEVEL=[debug,info,trace] environment
+// variable
+//
+// Tags for the BDD features can be set with either the
+// --tag="tag1,tag2" flag or
+//SY_TAG=tag1,tag2" environment variable
+//
+// Variables used when creating resources can be set with either the
+// --var="variable=value" flag, (can be set multiple times) or
+// SY_ENV_variable="value" environment values
+//
+// CreateResouces
+func ConfigFromEnv() *Config {
+	c := DefaultConfig()
+
+	flag.Parse()
+
+	setTagsFromEnv(c)
+	setTagsFromFlags(c, flagTags)
+
+	setVariablesFromFlags(c, flagVariables)
+
+	return c
+}
+
+func setTagsFromEnv(c *Config) {
+	env := os.Getenv("SY_TAG")
+	tags := strings.Split(env, ",")
+	c.Tags = append(c.Tags, tags...)
+}
+
+func setTagsFromFlags(c *Config, flags string) {
+	tags := strings.Split(flags, ",")
+	c.Tags = append(c.Tags, tags...)
+}
+
+func setVariablesFromFlags(c *Config, flags []string) {
+	for _, f := range flags {
+		parts := strings.Split(f, "=")
+		c.Variables[parts[0]] = parts[1]
+	}
+}
+
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+	// change this, this is just can example to satisfy the interface
+	return "my string representation"
+}
+
+func (i *arrayFlags) Set(value string) error {
+	v := strings.TrimSpace(value)
+	v = strings.TrimPrefix(v, `"`)
+	v = strings.TrimSuffix(v, `"`)
+
+	*i = append(*i, v)
+
+	return nil
+}

--- a/pkg/testing/config_test.go
+++ b/pkg/testing/config_test.go
@@ -1,0 +1,38 @@
+package testing
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfigCreatedWithCorrectValues(t *testing.T) {
+	c := DefaultConfig()
+
+	require.Equal(t, "info", c.LogLevel)
+	require.True(t, c.CreateResources)
+	require.True(t, c.DestroyResources)
+	require.Equal(t, "./", c.FeaturesPath)
+}
+
+func TestConfigFromEnvCreatesConfigWithTags(t *testing.T) {
+	os.Setenv("SY_TAG", "@foo,@bar")
+	os.Args = append(os.Args, "--tags=@one,@two")
+
+	c := ConfigFromEnv()
+
+	t.Cleanup(func() {
+		os.Unsetenv("SY_TAG")
+	})
+
+	require.Equal(t, []string{"@foo", "@bar", "@one", "@two"}, c.Tags)
+}
+
+func TestConfigFromEnvCreatesConfigWithVariables(t *testing.T) {
+	os.Args = append(os.Args, `--var="foo=bar"`, `--var="count=1"`)
+
+	c := ConfigFromEnv()
+
+	require.Equal(t, map[string]string{"foo": "bar", "count": "1"}, c.Variables)
+}

--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -1,0 +1,154 @@
+package testing
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/colors"
+	"github.com/hashicorp/go-hclog"
+	"github.com/shipyard-run/shipyard/pkg/shipyard"
+)
+
+type Runner interface {
+	// SetOutputWriter sets the writer used for output
+	// defaults to os.StdOut
+	SetOutputWriter(w io.Writer)
+	// BeforeSuite runs the given function before the suite of tests runs
+	BeforeSuite(func() error)
+	// AfterSuite runs the given function after the suite of tests has run
+	AfterSuite(func() error)
+	// Allows a function to be executed before the Scenario runs
+	BeforeScenario(func() error)
+	// Allows a function to be executed after the Scenario runs
+	AfterScenario(func() error)
+	// RegsiterStep registers a custom step
+	RegisterStep(expr string, stepFunc interface{})
+	// Run the tests
+	Run() error
+}
+
+// goDogRunner is an implementation of Runner for the GoDog Cucumber tool
+type goDogRunner struct {
+	config         *Config
+	engine         shipyard.Engine
+	output         *os.File
+	engineLog      *bytes.Buffer
+	beforeScenario func() error
+	afterScenario  func() error
+	beforeSuite    func() error
+	afterSuite     func() error
+	customSteps    map[string]interface{}
+}
+
+// NewRunner creates a new Runner with the given configuration
+func NewRunner(config *Config) Runner {
+	engineLog := &bytes.Buffer{}
+
+	lo := &hclog.LoggerOptions{
+		Level:  hclog.Debug,
+		Output: engineLog,
+	}
+
+	hl := hclog.New(lo)
+
+	engine, err := shipyard.New(hl)
+	if err != nil {
+		panic(err)
+	}
+
+	return &goDogRunner{
+		config,
+		engine,
+		os.Stdout,
+		engineLog,
+		nil,
+		nil,
+		nil,
+		nil,
+		map[string]interface{}{},
+	}
+}
+
+func (gd *goDogRunner) SetOutputWriter(w io.Writer) {}
+
+func (gd *goDogRunner) BeforeSuite(bs func() error) {
+	gd.beforeSuite = bs
+}
+
+func (gd *goDogRunner) AfterSuite(as func() error) {
+	gd.afterSuite = as
+}
+
+func (gd *goDogRunner) BeforeScenario(bs func() error) {
+	gd.beforeScenario = bs
+}
+
+func (gd *goDogRunner) AfterScenario(as func() error) {
+	gd.afterScenario = as
+}
+
+func (gd *goDogRunner) RegisterStep(expr string, stepFunc interface{}) {
+	gd.customSteps[expr] = stepFunc
+}
+
+func (gd *goDogRunner) Run() error {
+	var opts = &godog.Options{
+		Format: "pretty",
+		Output: colors.Colored(gd.output),
+		Paths:  []string{gd.config.FeaturesPath},
+		Tags:   strings.Join(gd.config.Tags, ","),
+	}
+
+	status := godog.TestSuite{
+		Name:                "Shipyard test",
+		ScenarioInitializer: gd.initializeSuite,
+		Options:             opts,
+	}.Run()
+
+	if status == 1 {
+		return fmt.Errorf("Error running test suite")
+	}
+
+	if gd.afterSuite != nil {
+		gd.afterSuite()
+	}
+
+	return nil
+}
+
+func (gd *goDogRunner) initializeSuite(ctx *godog.ScenarioContext) {
+	ctx.BeforeScenario(func(gs *godog.Scenario) {
+		if gd.beforeScenario != nil {
+			gd.beforeScenario()
+		}
+	})
+
+	ctx.AfterScenario(func(gs *godog.Scenario, err error) {
+		if gd.afterScenario != nil {
+			gd.afterScenario()
+		}
+
+		gd.engine.Destroy("", true)
+
+		if err != nil {
+			fmt.Fprintln(gd.output, gd.engineLog.String())
+		}
+	})
+
+	// register default steps
+	ctx.Step(`^I have a running blueprint$`, gd.iRunApply)
+	ctx.Step(`^I have a running blueprint at path "([^"]*)"$`, gd.iRunApplyAtPath)
+
+	// register custom steps
+	for k, v := range gd.customSteps {
+		ctx.Step(k, v)
+	}
+
+	if gd.beforeSuite != nil {
+		gd.beforeSuite()
+	}
+}

--- a/pkg/testing/runner_test.go
+++ b/pkg/testing/runner_test.go
@@ -1,0 +1,100 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/shipyard-run/shipyard/pkg/shipyard/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRunner(t *testing.T) (Runner, *mocks.Engine) {
+	c := DefaultConfig()
+	c.FeaturesPath = "./test_fixtures"
+
+	me := &mocks.Engine{}
+	me.On("ApplyWithVariables", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	me.On("Destroy", mock.Anything, mock.Anything).Return(nil)
+
+	r := NewRunner(c, me)
+
+	// setup the default steps to stop test failures
+	r.RegisterStep(`I expect a step to be called`, func() error { return nil })
+
+	return r, me
+}
+
+func TestRunCallsCustomSteps(t *testing.T) {
+	r, _ := setupRunner(t)
+
+	stepCalled := false
+	r.RegisterStep(`I expect a step to be called`, func() error {
+		stepCalled = true
+		return nil
+	})
+
+	err := r.Run()
+	require.NoError(t, err)
+
+	require.True(t, stepCalled)
+}
+
+func TestRunCallsBeforeScenario(t *testing.T) {
+	r, _ := setupRunner(t)
+
+	beforeCalled := false
+	r.BeforeScenario(func() error {
+		beforeCalled = true
+		return nil
+	})
+
+	err := r.Run()
+	require.NoError(t, err)
+
+	require.True(t, beforeCalled)
+}
+
+func TestRunCallsAfterScenario(t *testing.T) {
+	r, _ := setupRunner(t)
+
+	afterCalled := false
+	r.AfterScenario(func() error {
+		afterCalled = true
+		return nil
+	})
+
+	err := r.Run()
+	require.NoError(t, err)
+
+	require.True(t, afterCalled)
+}
+
+func TestRunCallsBeforeSuite(t *testing.T) {
+	r, _ := setupRunner(t)
+
+	beforeCalled := false
+	r.BeforeSuite(func() error {
+		beforeCalled = true
+		return nil
+	})
+
+	err := r.Run()
+	require.NoError(t, err)
+
+	require.True(t, beforeCalled)
+}
+
+func TestRunCallsAfterSuite(t *testing.T) {
+	r, _ := setupRunner(t)
+
+	afterCalled := false
+	r.AfterSuite(func() error {
+		afterCalled = true
+		return nil
+	})
+
+	err := r.Run()
+	require.NoError(t, err)
+
+	require.True(t, afterCalled)
+}

--- a/pkg/testing/test_fixtures/container.hcl
+++ b/pkg/testing/test_fixtures/container.hcl
@@ -1,0 +1,34 @@
+variable "version" {
+  default = "consul:1.6.1"
+}
+
+network "onprem" {
+  subnet = "10.6.0.0/16"
+}
+
+container "consul" {
+  image   {
+    name = var.version
+  }
+
+  command = ["consul", "agent", "-dev", "-client", "0.0.0.0"]
+
+  network   {
+    name = "network.onprem"
+    ip_address = "10.6.0.200"
+  }
+  
+  port_range {
+    range       = "8500-8502"
+    enable_host = true
+  }
+
+  resources {
+    # Max CPU to consume, 1024 is one core, default unlimited
+    cpu = 2048
+    # Pin container to specified CPU cores, default all cores
+    cpu_pin = [1]
+    # max memory in MB to consume, default unlimited
+    memory = 1024
+  }
+}

--- a/pkg/testing/test_fixtures/example.go
+++ b/pkg/testing/test_fixtures/example.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/shipyard-run/shipyard/pkg/testing"
+)
+
+func main() {
+	c := testing.DefaultConfig()
+	r := testing.NewRunner(c)
+
+	// setup the default steps to stop test failures
+	r.RegisterStep(`I expect a step to be called`, func() error { return nil })
+
+	r.Run()
+}

--- a/pkg/testing/test_fixtures/features/example.feature
+++ b/pkg/testing/test_fixtures/features/example.feature
@@ -1,0 +1,8 @@
+Feature: access.smi-spec.io
+  In order to test the testing library
+  As a developer
+  I need to ensure the specification is executed by godog
+
+  Scenario: Test custom step
+    Given I have a running blueprint
+    Then I expect a step to be called


### PR DESCRIPTION
This feature moves the `shipyard test` functionality into an importable package. This enables the use of Shipyards test capability from both the command line `shipyard test` and as an importable Go package.

```go
package main

import (
	"github.com/shipyard-run/shipyard/pkg/testing"
)

func main() {
	c := testing.DefaultConfig()
	r := testing.NewRunner(c)

	// setup the default steps to stop test failures
	r.RegisterStep(`I expect a step to be called`, func() error { return nil })

	r.Run()
}
```

Developers can use the Shipyard library to create a functional test suite that spins up infrastructure and tears it down before the execution of BDD-based test specs.