### PR TITLE
Generates a default formatted readme for a module

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate jumppad stuff",
+	Long:  `Generate jumppad stuff`,
+}

--- a/cmd/generate_readme.go
+++ b/cmd/generate_readme.go
@@ -52,8 +52,9 @@ func newGenerateReadmeCommand(e shipyard.Engine) *cobra.Command {
 
 			// print the authors
 			cmd.Println("| <!-- -->    | <!-- -->    |")
-			cmd.Println("| Author | %s |", blueprint.Author)
-			cmd.Println("| Slug | %s |", blueprint.Slug)
+			cmd.Println("| ---- |  ----------- |")
+			cmd.Printf("| Author | %s |\n", blueprint.Author)
+			cmd.Printf("| Slug | %s |\n", blueprint.Slug)
 			cmd.Println("")
 
 			cmd.Println("## Description")
@@ -74,11 +75,11 @@ func newGenerateReadmeCommand(e shipyard.Engine) *cobra.Command {
 				cmd.Println("These variables can be set to configure this blueprint")
 				cmd.Println("")
 
-				cmd.Println("| Name | Default | Description |")
-				cmd.Println("| ---- | ------- | ----------- |")
+				cmd.Println("| Name |  Description |")
+				cmd.Println("| ---- |  ----------- |")
 
 				for _, v := range variables {
-					cmd.Printf("| %s | %s | %s |\n", v.Name, v.Default, v.Description)
+					cmd.Printf("| %s | %s |\n", v.Name, v.Description)
 				}
 				cmd.Println("")
 			}
@@ -102,7 +103,7 @@ func newGenerateReadmeCommand(e shipyard.Engine) *cobra.Command {
 				cmd.Println("| ---- |  ----------- |")
 
 				for _, v := range outputs {
-					cmd.Printf("| %s | %s |\n", v.Name, "")
+					cmd.Printf("| %s | %s |\n", v.Name, v.Description)
 				}
 				cmd.Println("")
 			}

--- a/cmd/generate_readme.go
+++ b/cmd/generate_readme.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"github.com/jumppad-labs/jumppad/pkg/config/resources"
+	"github.com/jumppad-labs/jumppad/pkg/shipyard"
+	"github.com/shipyard-run/hclconfig/types"
+	"github.com/spf13/cobra"
+)
+
+func newGenerateReadmeCommand(e shipyard.Engine) *cobra.Command {
+	connectorRunCmd := &cobra.Command{
+		Use:   "readme",
+		Short: "Generate a markdown readme for the blueprints",
+		Long:  `Generate a markdown readme for the blueprints`,
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			dst := ""
+			if len(args) == 1 {
+				dst = args[0]
+			} else {
+				dst = "./"
+			}
+
+			if dst == "." {
+				dst = "./"
+			}
+
+			_, err := e.ParseConfig(dst)
+			if err != nil {
+				return err
+			}
+
+			// find a blueprint
+			var blueprint *resources.Blueprint
+			bps, _ := e.Config().FindResourcesByType(resources.TypeBlueprint)
+			for _, bp := range bps {
+				// pick the first blueprint in the root
+				if bp.Metadata().Module == "" {
+					blueprint = bp.(*resources.Blueprint)
+					break
+				}
+			}
+
+			if blueprint == nil {
+				return nil
+			}
+
+			// print the title
+			cmd.Printf("# %s\n", blueprint.Title)
+			cmd.Println("")
+
+			// print the authors
+			cmd.Println("| <!-- -->    | <!-- -->    |")
+			cmd.Println("| Author | %s |", blueprint.Author)
+			cmd.Println("| Slug | %s |", blueprint.Slug)
+			cmd.Println("")
+
+			cmd.Println("## Description")
+			cmd.Println(blueprint.Description)
+
+			variables := []*types.Variable{}
+			os, _ := e.Config().FindResourcesByType(types.TypeVariable)
+			for _, o := range os {
+				// only grab the root outputs
+				if o.Metadata().Module == "" {
+					variables = append(variables, o.(*types.Variable))
+				}
+			}
+
+			if len(variables) > 0 {
+				cmd.Println("## Variables")
+
+				cmd.Println("These variables can be set to configure this blueprint")
+				cmd.Println("")
+
+				cmd.Println("| Name | Default | Description |")
+				cmd.Println("| ---- | ------- | ----------- |")
+
+				for _, v := range variables {
+					cmd.Printf("| %s | %s | %s |\n", v.Name, v.Default, v.Description)
+				}
+				cmd.Println("")
+			}
+
+			outputs := []*types.Output{}
+			os, _ = e.Config().FindResourcesByType(types.TypeOutput)
+			for _, o := range os {
+				// only grab the root outputs
+				if o.Metadata().Module == "" {
+					outputs = append(outputs, o.(*types.Output))
+				}
+			}
+
+			if len(outputs) > 0 {
+				cmd.Println("## Outputs")
+
+				cmd.Println("These blueprint sets the following outputs")
+				cmd.Println("")
+
+				cmd.Println("| Name |  Description |")
+				cmd.Println("| ---- |  ----------- |")
+
+				for _, v := range outputs {
+					cmd.Printf("| %s | %s |\n", v.Name, "")
+				}
+				cmd.Println("")
+			}
+
+			return nil
+		},
+	}
+
+	return connectorRunCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,10 @@ func init() {
 	connectorCmd.AddCommand(newConnectorRunCommand())
 	connectorCmd.AddCommand(connectorStopCmd)
 	connectorCmd.AddCommand(newConnectorCertCmd())
+
+	// add the generate command
+	rootCmd.AddCommand(generateCmd)
+	generateCmd.AddCommand(newGenerateReadmeCommand(engine))
 }
 
 func createEngine(l hclog.Logger) (shipyard.Engine, gvm.Versions) {

--- a/examples/container/blueprint.hcl
+++ b/examples/container/blueprint.hcl
@@ -1,0 +1,29 @@
+resource "blueprint" "container" {
+  title       = "Simple container example"
+  author      = "Nic Jackson<jackson.nic@gmail.com>"
+  slug        = "container"
+  description = <<-EOF
+    This is the description for the blueprint, it can contain
+    markdown such as:
+
+    ## Column headings
+    And things like bulleted lists
+
+    * one
+    * two
+    * three
+
+    ### Example Usage
+    It is also possible to incude code blocks
+
+    ```hcl
+    module "one" {
+      source = "./subfolder"
+
+      variables = {
+        nodes = 1
+      }
+    }
+    ```
+  EOF
+}

--- a/examples/container/blueprint.hcl
+++ b/examples/container/blueprint.hcl
@@ -6,14 +6,14 @@ resource "blueprint" "container" {
     This is the description for the blueprint, it can contain
     markdown such as:
 
-    ## Column headings
+    ### Column headings
     And things like bulleted lists
 
     * one
     * two
     * three
 
-    ### Example Usage
+    #### Example Usage
     It is also possible to incude code blocks
 
     ```hcl

--- a/examples/container/output.hcl
+++ b/examples/container/output.hcl
@@ -1,3 +1,4 @@
 output "consul_http_addr" {
-  value = "http://${resource.container.consul.fqrn}:8500"
+  description = "HTTP address for the consul server"
+  value       = "http://${resource.container.consul.fqrn}:8500"
 }

--- a/examples/container/variables.hcl
+++ b/examples/container/variables.hcl
@@ -1,0 +1,4 @@
+variable "number_of_nodes" {
+  default     = 1
+  description = "Controls the number of nodes for the Consul server"
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/shipyard-run/gohup v0.2.2
-	github.com/shipyard-run/hclconfig v0.5.2
+	github.com/shipyard-run/hclconfig v0.5.3
 	github.com/shipyard-run/version-manager v0.0.5
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1410,6 +1410,8 @@ github.com/shipyard-run/gohup v0.2.2 h1:yIJhQ7BItGd2cZmWeuxCneTNriIxLGaPtMt1FsW1
 github.com/shipyard-run/gohup v0.2.2/go.mod h1:jgPnkGXOn4ca6tCWUHw2FUhhvxiMskROiRIoYMYEYHM=
 github.com/shipyard-run/hclconfig v0.5.2 h1:O2nOjNbc6b4glN0b5aeOHib28MyaXg1JDRlktBlQj1M=
 github.com/shipyard-run/hclconfig v0.5.2/go.mod h1:MnKRPprx0QkCBQYS6rZXClSTVccZPMFZ0Q7i5t+9SIg=
+github.com/shipyard-run/hclconfig v0.5.3 h1:s/7amv3mZvQ/zTpxWLWBz5Dap0O+NFF+DYGNiRJ6oqc=
+github.com/shipyard-run/hclconfig v0.5.3/go.mod h1:MnKRPprx0QkCBQYS6rZXClSTVccZPMFZ0Q7i5t+9SIg=
 github.com/shipyard-run/version-manager v0.0.5 h1:gswTn7y/f2yoUOGl9tu18Bbp84EQa7gtqMNBbPu78BA=
 github.com/shipyard-run/version-manager v0.0.5/go.mod h1:odqsb09c70cTpSnm1rhQpBV1j7dF3N1FGzdiz8W0n+c=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/pkg/config/resources/blueprint.go
+++ b/pkg/config/resources/blueprint.go
@@ -1,42 +1,16 @@
 package resources
 
-import (
-	"fmt"
-	"net/url"
-)
+import "github.com/shipyard-run/hclconfig/types"
+
+// TypeContainer is the resource string for a Container resource
+const TypeBlueprint string = "blueprint"
 
 // Blueprint defines a stack blueprint for defining yard configs
 type Blueprint struct {
-	Title              string            `hcl:"title,optional" json:"title,omitempty"`
-	Author             string            `hcl:"author,optional" json:"author,omitempty"`
-	Slug               string            `hcl:"slug,optional" json:"slug,omitempty"`
-	Intro              string            `hcl:"intro,optional" json:"intro,omitempty"`
-	BrowserWindows     []string          `hcl:"browser_windows,optional" json:"browser_windows,omitempty"`
-	HealthCheckTimeout string            `hcl:"health_check_timeout,optional" json:"health_check_timeout,omitempty"`
-	Environment        map[string]string `hcl:"env,optional" json:"environment,omitempty"`
-	ShipyardVersion    string            `hcl:"shipyard_version,optional" json:"shipyard_version,omitempty"`
-}
+	types.ResourceMetadata `hcl:",remain"`
 
-// Validate the Blueprint and return errors
-func (b *Blueprint) Validate() []error {
-	errors := make([]error, 0)
-	// ensure BrowserWindows are valid URIs
-	for _, i := range b.BrowserWindows {
-		uri, err := url.Parse(i)
-		if err != nil {
-			errors = append(
-				errors,
-				fmt.Errorf("invalid BrowserWindow URI: %s, %s", i, err),
-			)
-		}
-
-		if uri.String() == "" {
-			errors = append(
-				errors,
-				fmt.Errorf("invalid BrowserWindow URI, uri is empty: %s", i),
-			)
-		}
-	}
-
-	return errors
+	Title       string `hcl:"title,optional" json:"title,omitempty"`
+	Author      string `hcl:"author,optional" json:"author,omitempty"`
+	Slug        string `hcl:"slug,optional" json:"slug,omitempty"`
+	Description string `hcl:"description,optional" json:"description,omitempty"`
 }

--- a/pkg/config/resources/ingress.go
+++ b/pkg/config/resources/ingress.go
@@ -9,12 +9,6 @@ import (
 // TypeIngress is the resource string for the type
 const TypeIngress string = "ingress"
 
-const (
-	IngressSourceLocal  = "local"
-	IngressSourceK8s    = "k8s"
-	IngressSourceDocker = "docker"
-)
-
 // Ingress defines an ingress service mapping ports between local host and resources like containers and kube cluster
 type Ingress struct {
 	types.ResourceMetadata `hcl:",remain"`
@@ -24,6 +18,9 @@ type Ingress struct {
 
 	// details for the destination service
 	Target TrafficTarget `hcl:"target,block" json:"target"`
+
+	// path to open in the browser
+	OpenInBrowser string `hcl:"open_in_browser,optional" json:"open_in_browser,omitempty"`
 
 	// --- Output Params ----
 

--- a/pkg/config/resources/zz_hclparser.go
+++ b/pkg/config/resources/zz_hclparser.go
@@ -19,6 +19,7 @@ func SetupHCLConfig(callback hclconfig.ProcessCallback, variables map[string]str
 	p := hclconfig.NewParser(cfg)
 
 	// Register the types
+	p.RegisterType(TypeBlueprint, &Blueprint{})
 	p.RegisterType(TypeCertificateCA, &CertificateCA{})
 	p.RegisterType(TypeCertificateLeaf, &CertificateLeaf{})
 	p.RegisterType(TypeContainer, &Container{})

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -348,7 +348,7 @@ func (e *EngineImpl) readAndProcessConfig(path string, variables map[string]stri
 	}
 
 	// process is not called for module resources, add manually
-	err = e.appendModuleResources(parsedConfig)
+	err = e.appendModuleAndVariableResources(parsedConfig)
 	if err != nil {
 		return parseError
 	}
@@ -420,13 +420,13 @@ func (e *EngineImpl) appendDisabledResources(c *hclconfig.Config) error {
 }
 
 // appends module in the given config to the engines config
-func (e *EngineImpl) appendModuleResources(c *hclconfig.Config) error {
+func (e *EngineImpl) appendModuleAndVariableResources(c *hclconfig.Config) error {
 	if c == nil {
 		return nil
 	}
 
 	for _, r := range c.Resources {
-		if r.Metadata().Type == types.TypeModule {
+		if r.Metadata().Type == types.TypeModule || r.Metadata().Type == types.TypeVariable {
 			// if the resource already exists remove it
 			er, err := e.config.FindResource(types.FQDNFromResource(r).String())
 			if err == nil {
@@ -436,7 +436,7 @@ func (e *EngineImpl) appendModuleResources(c *hclconfig.Config) error {
 			// add the resource to the state
 			err = e.config.AppendResource(r)
 			if err != nil {
-				return fmt.Errorf("unable to add module resource: %s", err)
+				return fmt.Errorf("unable to add resource: %s", err)
 			}
 		}
 	}

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -37,9 +37,7 @@ type Engine interface {
 	ParseConfig(string) ([]types.Resource, error)
 	ParseConfigWithVariables(string, map[string]string, string) ([]types.Resource, error)
 	Destroy() error
-	ResourceCount() int
-	ResourceCountForType(string) int
-	Blueprint() *resources.Blueprint
+	Config() *hclconfig.Config
 }
 
 // EngineImpl is responsible for creating and destroying resources
@@ -127,8 +125,9 @@ func (e *EngineImpl) GetClients() *clients.Clients {
 	return e.clients
 }
 
-func (e *EngineImpl) Blueprint() *resources.Blueprint {
-	return nil
+// Config returns the parsed config
+func (e *EngineImpl) Config() *hclconfig.Config {
+	return e.config
 }
 
 // ParseConfig parses the given Shipyard files and creating the resource types but does

--- a/pkg/shipyard/providers.go
+++ b/pkg/shipyard/providers.go
@@ -10,6 +10,8 @@ import (
 // generateProviderImpl returns providers grouped together in order of execution
 func generateProviderImpl(c types.Resource, cc *clients.Clients) providers.Provider {
 	switch c.Metadata().Type {
+	case resources.TypeBlueprint:
+		return providers.NewNull(c.Metadata(), cc.Logger)
 	case resources.TypeCertificateCA:
 		return providers.NewCertificateCA(c.(*resources.CertificateCA), cc.Logger)
 	case resources.TypeCertificateLeaf:


### PR DESCRIPTION
Enables automated readme generation for blueprints, this command can save maintainers the trouble of generating readmes.



----- Example ----

# Simple container example

|  <!-- -->   |  <!-- -->   |
| ---- | ---- |
| Author |  Nic Jackson<jackson.nic@gmail.com> |
| Slug | container |

## Description
This is the description for the blueprint, it can contain
markdown such as:

### Column headings
And things like bulleted lists

* one
* two
* three

#### Example Usage
It is also possible to incude code blocks

```hcl
module "one" {
  source = "./subfolder"

  variables = {
    nodes = 1
  }
}
```

## Variables
These variables can be set to configure this blueprint

| Name |  Description |
| ---- |  ----------- |
| consul_version |  | %!s(MISSING) |
| envoy_version |  | %!s(MISSING) |
| number_of_nodes | Controls the number of nodes for the Consul server | %!s(MISSING) |

## Outputs
These blueprint sets the following outputs

| Name |  Description |
| ---- |  ----------- |
| consul_http_addr | HTTP address for the consul server |