### PR TITLE
Add complex outputs

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime"
@@ -70,7 +71,9 @@ func newEnvCmd(e jumppad.Engine) *cobra.Command {
 						continue
 					}
 
-					val := strings.ReplaceAll(r.(*types.Output).Value, `\`, `\\`)
+					d, _ := json.Marshal(r.(*types.Output).Value)
+					val := strings.ReplaceAll(string(d), `\`, `\\`)
+					val = strings.ReplaceAll(val, `"`, `\"`)
 					if unset {
 						fmt.Printf("%s%s\n", prefix, r.Metadata().Name)
 					} else {

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 
@@ -23,7 +25,7 @@ var outputCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		out := map[string]string{}
+		out := map[string]interface{}{}
 		// get the output variables
 		for _, r := range cfg.Resources {
 			if r.Metadata().Type == types.TypeOutput {
@@ -38,14 +40,15 @@ var outputCmd = &cobra.Command{
 
 				out[r.Metadata().Name] = r.(*types.Output).Value
 
-				if len(args) > 0 && strings.ToLower(args[0]) == strings.ToLower(r.Metadata().Name) {
-					cmd.Println(r.(*types.Output).Value)
+				if len(args) > 0 && strings.EqualFold(args[0], r.Metadata().Name) {
+					d, _ := json.Marshal(r.(*types.Output).Value)
+					fmt.Printf("%s", string(d))
 					return
 				}
 			}
 		}
 
-		s, _ := prettyjson.Marshal(out)
-		cmd.Println(string(s))
+		d, _ := prettyjson.Marshal(out)
+		fmt.Printf("%s", string(d))
 	},
 }

--- a/examples/multiple_k3s_clusters/main.hcl
+++ b/examples/multiple_k3s_clusters/main.hcl
@@ -24,10 +24,20 @@ module "consul_dc2" {
   }
 }
 
-output "dc1_addr" {
-  value = module.consul_dc1.output.consul_http_addr
+output "dc1_id" {
+  value = module.consul_dc1.output.k8s_port
 }
 
-output "dc2_addr" {
-  value = module.consul_dc2.output.consul_http_addr
+output "addr_map" {
+  value = {
+    dc1 = module.consul_dc1.output.consul_http_addr
+    dc2 = module.consul_dc2.output.consul_http_addr
+  }
+}
+
+output "addr_list" {
+  value = [
+    module.consul_dc1.output.consul_http_addr,
+    module.consul_dc2.output.consul_http_addr
+  ]
 }

--- a/examples/multiple_k3s_clusters/module_k3s/outputs.hcl
+++ b/examples/multiple_k3s_clusters/module_k3s/outputs.hcl
@@ -1,3 +1,7 @@
+output "k8s_port" {
+  value = resource.random_number.port.value
+}
+
 output "consul_http_addr" {
   value = "http://${resource.ingress.consul_http.address}"
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f
 	github.com/jumppad-labs/connector v0.3.0
-	github.com/jumppad-labs/hclconfig v0.6.1
+	github.com/jumppad-labs/hclconfig v0.7.0
 	github.com/mailgun/raymond/v2 v2.0.48
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/opencontainers/image-spec v1.0.2
@@ -131,6 +131,8 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/kyokomi/emoji/v2 v2.2.8 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
@@ -216,6 +218,6 @@ require (
 
 replace github.com/creack/pty => github.com/photostorm/pty v1.1.18
 
-// replace github.com/jumppad-labs/hclconfig => ../../shipyard-run/hclconfig/
+// replace github.com/jumppad-labs/hclconfig => ../../jumppad-labs/hclconfig/
 
 //replace github.com/jumppad-labs/connector => ../connector

--- a/go.sum
+++ b/go.sum
@@ -1053,8 +1053,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jumppad-labs/connector v0.3.0 h1:C+6YpMfhRBzuCAmkDpYEWbIIYN7q6gB9kWRPxvrBIew=
 github.com/jumppad-labs/connector v0.3.0/go.mod h1:PqRmJZKayHw4j8JfNkugRMtdQF8ldjdTvtmTxF3O/44=
-github.com/jumppad-labs/hclconfig v0.6.1 h1:emfQ65clvB6tlraCOHF/NyuuOzRhhBXoe9UyARG/za8=
-github.com/jumppad-labs/hclconfig v0.6.1/go.mod h1:ewMp7uM+9kHRbXpHCOqPL3IRPDESTMOIJ+tmcp4vwCM=
+github.com/jumppad-labs/hclconfig v0.7.0 h1:TwYRJgQ3XCfVKMqPAEiftIllP0qDp+pee69sKSshi+I=
+github.com/jumppad-labs/hclconfig v0.7.0/go.mod h1:3WhIYMrbmFXrTO2/UQgAWz4lXwehonglnheIAyO9P48=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.15.8 h1:7+rWAZPn9zuRxaIqqT8Ohs2Q2Ac0msBqwRdxNCr2VVs=
 github.com/karrick/godirwalk v1.15.8/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=


### PR DESCRIPTION
It is now possible to have complex types like maps and strings for outputs, as shown in the example below.

```hcl
output "dc1_id" {
  value = module.consul_dc1.output.k8s_port
}

output "addr_map" {
  value = {
    dc1 = module.consul_dc1.output.consul_http_addr
    dc2 = module.consul_dc2.output.consul_http_addr
  }
}

output "addr_list" {
  value = [
    module.consul_dc1.output.consul_http_addr,
    module.consul_dc2.output.consul_http_addr
  ]
}
```