### PR TITLE
Properly set hostname for docker containers.

### DIFF
--- a/pkg/clients/container/docker_tasks.go
+++ b/pkg/clients/container/docker_tasks.go
@@ -129,8 +129,10 @@ func (d *DockerTasks) CreateContainer(c *dtypes.Container) (string, error) {
 	}
 
 	// create the container config
+	hostname, domain, _ := strings.Cut(c.Name, ".")
 	dc := &container.Config{
-		Hostname:     c.Name,
+		Hostname:     hostname,
+		Domainname:   domain,
 		Image:        c.Image.Name,
 		Env:          env,
 		Cmd:          c.Command,


### PR DESCRIPTION
Previously the FQDN was set as hostname. This is not valid since the hostname should be only the part before the first dot. This becomes visible when starting a consul container which will then warn that it cannot use the hostname as node_name because it contains invalid characters.

Warning from consul:
```
2023-08-27T17:44:09.096Z [WARN]  agent: Node name "consul.container.jumppad.dev" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.
```