### PR TITLE
Add support for selinux relabeling in volumes.

### DIFF
--- a/pkg/clients/container/types/types.go
+++ b/pkg/clients/container/types/types.go
@@ -52,6 +52,7 @@ type Volume struct {
 	ReadOnly                    bool
 	BindPropagation             string
 	BindPropagationNonRecursive bool
+	SelinuxRelabel              string
 }
 
 // Port is a port mapping

--- a/pkg/config/resources/container/convert.go
+++ b/pkg/config/resources/container/convert.go
@@ -46,6 +46,7 @@ func (v Volume) ToClientVolume() types.Volume {
 		ReadOnly:                    v.ReadOnly,
 		BindPropagation:             v.BindPropagation,
 		BindPropagationNonRecursive: v.BindPropagationNonRecursive,
+		SelinuxRelabel:              v.SelinuxRelabel,
 	}
 }
 

--- a/pkg/config/resources/container/provider.go
+++ b/pkg/config/resources/container/provider.go
@@ -194,6 +194,7 @@ func (c *Provider) internalCreate(sidecar bool) error {
 			ReadOnly:                    v.ReadOnly,
 			BindPropagation:             v.BindPropagation,
 			BindPropagationNonRecursive: v.BindPropagationNonRecursive,
+			SelinuxRelabel:              v.SelinuxRelabel,
 		})
 	}
 

--- a/pkg/config/resources/container/resource_container.go
+++ b/pkg/config/resources/container/resource_container.go
@@ -84,6 +84,7 @@ type Volume struct {
 	ReadOnly                    bool   `hcl:"read_only,optional" json:"read_only,omitempty"`                                           // specify that the volume is mounted read only
 	BindPropagation             string `hcl:"bind_propagation,optional" json:"bind_propagation,omitempty"`                             // propagation mode for bind mounts [shared, private, slave, rslave, rprivate]
 	BindPropagationNonRecursive bool   `hcl:"bind_propagation_non_recursive,optional" json:"bind_propagation_non_recursive,omitempty"` // recursive bind mount, default true
+	SelinuxRelabel              string `hcl:"selinux_relabel,optional" json:"selinux_relabel,optional"`                                // selinux_relabeling ["", shared, private]
 }
 
 type Volumes []Volume

--- a/pkg/config/resources/exec/provider_remote.go
+++ b/pkg/config/resources/exec/provider_remote.go
@@ -150,6 +150,7 @@ func (p *RemoteProvider) createRemoteExecContainer() (string, error) {
 			ReadOnly:                    v.ReadOnly,
 			BindPropagation:             v.BindPropagation,
 			BindPropagationNonRecursive: v.BindPropagationNonRecursive,
+			SelinuxRelabel:              v.SelinuxRelabel,
 		})
 	}
 

--- a/pkg/config/resources/k8s/provider_cluster.go
+++ b/pkg/config/resources/k8s/provider_cluster.go
@@ -289,6 +289,7 @@ func (p *ClusterProvider) createK3s() error {
 			ReadOnly:                    v.ReadOnly,
 			BindPropagation:             v.BindPropagation,
 			BindPropagationNonRecursive: v.BindPropagationNonRecursive,
+			SelinuxRelabel:              v.SelinuxRelabel,
 		})
 	}
 


### PR DESCRIPTION
Docker does not support non-recursive binds with the src:target:options format and does not support selinux relabeling with type=bind,src=/src,target=/target,options. So we need to error out if both are requested :)

Where should I add tests for this?