### PR TITLE
make remote optional in preparation to deprecate it.

### DIFF
--- a/pkg/config/resources/container/provider.go
+++ b/pkg/config/resources/container/provider.go
@@ -202,7 +202,7 @@ func (c *Provider) internalCreate(sidecar bool) error {
 	for _, p := range c.config.Ports {
 		new.Ports = append(new.Ports, types.Port{
 			Local:         p.Local,
-			Remote:        p.Remote,
+			Remote:        p.Local,
 			Host:          p.Host,
 			Protocol:      p.Protocol,
 			OpenInBrowser: p.OpenInBrowser,
@@ -244,7 +244,7 @@ func (c *Provider) internalCreate(sidecar bool) error {
 		for i, net := range c.config.Networks {
 			if net.ID == n.ID {
 				// remove the netmask
-				ip,_,_ := strings.Cut(n.IPAddress, "/")
+				ip, _, _ := strings.Cut(n.IPAddress, "/")
 
 				// set the assigned address and name
 				c.config.Networks[i].AssignedAddress = ip

--- a/pkg/config/resources/container/resource_port.go
+++ b/pkg/config/resources/container/resource_port.go
@@ -3,7 +3,7 @@ package container
 // Port is a port mapping
 type Port struct {
 	Local         string `hcl:"local" json:"local"`                                                             // Local port in the container
-	Remote        string `hcl:"remote" json:"remote"`                                                           // Remote port of the service
+	Remote        string `hcl:"remote,optional" json:"remote"`                                                  // Remote port of the service
 	Host          string `hcl:"host,optional" json:"host,omitempty"`                                            // Host port
 	Protocol      string `hcl:"protocol,optional" json:"protocol,omitempty"`                                    // Protocol tcp, udp
 	OpenInBrowser string `hcl:"open_in_browser,optional" json:"open_in_browser" mapstructure:"open_in_browser"` // When a host port is defined open this port with the given path in a browser


### PR DESCRIPTION
Made remote on the container port stanza optional so we can deprecate it later and get rid of it.
Setting the remote field of the port stanza to the value of the local port until then as that is what people set it to anyway.