### PR TITLE
Add the ability to add or drop capabilities from containers

### DIFF
--- a/examples/container/container.hcl
+++ b/examples/container/container.hcl
@@ -48,6 +48,18 @@ resource "container" "consul_disabled" {
   }
 }
 
+
+resource "container" "consul_capabilities" {
+  image {
+    name = "consul:${variable.consul_version}"
+  }
+
+  capabilities {
+    add = ["NET_ADMIN"]
+    drop = ["ALL"]
+  }
+}
+
 resource "container" "consul" {
   image {
     name = "consul:${variable.consul_version}"

--- a/pkg/clients/container/docker_tasks.go
+++ b/pkg/clients/container/docker_tasks.go
@@ -149,6 +149,11 @@ func (d *DockerTasks) CreateContainer(c *dtypes.Container) (string, error) {
 		hc.RestartPolicy = container.RestartPolicy{Name: "on-failure", MaximumRetryCount: c.MaxRestartCount}
 	}
 
+	if c.Capabilities != nil {
+		hc.CapAdd = c.Capabilities.Add
+		hc.CapDrop = c.Capabilities.Drop
+	}
+
 	// https: //docs.docker.com/config/containers/resource_constraints/#cpu
 	rc := container.Resources{}
 	if c.Resources != nil {

--- a/pkg/clients/container/types/types.go
+++ b/pkg/clients/container/types/types.go
@@ -12,6 +12,7 @@ type Container struct {
 	PortRanges      []PortRange
 	DNS             []string
 	Privileged      bool
+	Capabilities    *Capabilities
 	MaxRestartCount int
 
 	// resource constraints
@@ -35,6 +36,11 @@ type NetworkAttachment struct {
 	Aliases     []string
 	Subnet      string
 	IsContainer bool // is the network attachment a container or normal network
+}
+
+type Capabilities struct {
+	Add  []string
+	Drop []string
 }
 
 // Resources allows the setting of resource constraints for the Container

--- a/pkg/config/resources/container/provider.go
+++ b/pkg/config/resources/container/provider.go
@@ -217,6 +217,13 @@ func (c *Provider) internalCreate(sidecar bool) error {
 		})
 	}
 
+	if c.config.Capabilities != nil {
+		new.Capabilities = &types.Capabilities{
+			Add:  c.config.Capabilities.Add,
+			Drop: c.config.Capabilities.Drop,
+		}
+	}
+
 	if c.config.Resources != nil {
 		new.Resources = &types.Resources{
 			CPU:    c.config.Resources.CPU,
@@ -244,7 +251,7 @@ func (c *Provider) internalCreate(sidecar bool) error {
 		for i, net := range c.config.Networks {
 			if net.ID == n.ID {
 				// remove the netmask
-				ip,_,_ := strings.Cut(n.IPAddress, "/")
+				ip, _, _ := strings.Cut(n.IPAddress, "/")
 
 				// set the assigned address and name
 				c.config.Networks[i].AssignedAddress = ip

--- a/pkg/config/resources/container/resource_container.go
+++ b/pkg/config/resources/container/resource_container.go
@@ -19,14 +19,15 @@ type Container struct {
 
 	Networks        []NetworkAttachment `hcl:"network,block" json:"networks,omitempty"`           // Attach to the correct network // only when Image is specified
 	Image           *Image              `hcl:"image,block" json:"image"`                          // Image to use for the container
-	Entrypoint      []string            `hcl:"entrypoint,optional" json:"entrypoint,omitempty"`   // entrypoint to use when starting the container
-	Command         []string            `hcl:"command,optional" json:"command,omitempty"`         // command to use when starting the container
-	Environment     map[string]string   `hcl:"environment,optional" json:"environment,omitempty"` // environment variables to set when starting the container
-	Volumes         []Volume            `hcl:"volume,block" json:"volumes,omitempty"`             // volumes to attach to the container
-	Ports           []Port              `hcl:"port,block" json:"ports,omitempty"`                 // ports to expose
-	PortRanges      []PortRange         `hcl:"port_range,block" json:"port_ranges,omitempty"`     // range of ports to expose
+	Entrypoint      []string            `hcl:"entrypoint,optional" json:"entrypoint,omitempty"`   // Entrypoint to use when starting the container
+	Command         []string            `hcl:"command,optional" json:"command,omitempty"`         // Command to use when starting the container
+	Environment     map[string]string   `hcl:"environment,optional" json:"environment,omitempty"` // Environment variables to set when starting the container
+	Volumes         []Volume            `hcl:"volume,block" json:"volumes,omitempty"`             // Volumes to attach to the container
+	Ports           []Port              `hcl:"port,block" json:"ports,omitempty"`                 // Ports to expose
+	PortRanges      []PortRange         `hcl:"port_range,block" json:"port_ranges,omitempty"`     // Range of ports to expose
 	DNS             []string            `hcl:"dns,optional" json:"dns,omitempty"`                 // Add custom DNS servers to the container
-	Privileged      bool                `hcl:"privileged,optional" json:"privileged,omitempty"`   // run the container in privileged mode?
+	Privileged      bool                `hcl:"privileged,optional" json:"privileged,omitempty"`   // Run the container in privileged mode?
+	Capabilities    *Capabilities       `hcl:"capabilities,block" json:"capabilities,omitempty"`  // Capabilities to add or drop from the container
 	MaxRestartCount int                 `hcl:"max_restart_count,optional" json:"max_restart_count,omitempty"`
 
 	// resource constraints
@@ -74,6 +75,11 @@ type Resources struct {
 	CPU    int   `hcl:"cpu,optional" json:"cpu,omitempty"`         // cpu limit for the container where 1 CPU = 1000
 	CPUPin []int `hcl:"cpu_pin,optional" json:"cpu_pin,omitempty"` // pin the container to one or more cpu cores
 	Memory int   `hcl:"memory,optional" json:"memory,omitempty"`   // max memory the container can consume in MB
+}
+
+type Capabilities struct {
+	Add  []string `hcl:"add,optional" json:"add"`   // CapAdd is a list of kernel capabilities to add to the container
+	Drop []string `hcl:"drop,optional" json:"drop"` // CapDrop is a list of kernel capabilities to remove from the container
 }
 
 // Volume defines a folder, Docker volume, or temp folder to mount to the Container


### PR DESCRIPTION
Made it possible to specify a capabilities block on containers where you can specify which to add and drop e.g.

```hcl
resource "container" "consul" {
  image {
    name = "consul:${variable.consul_version}"
  }

  capabilities {
    add = ["NET_ADMIN"]
    drop = ["ALL"]
  }
}
```