### PR TITLE
Allow users to add labels to containers

### DIFF
--- a/examples/container/container.hcl
+++ b/examples/container/container.hcl
@@ -60,6 +60,16 @@ resource "container" "consul_capabilities" {
   }
 }
 
+resource "container" "consul_labels" {
+  image {
+    name = "consul:${variable.consul_version}"
+  }
+
+  labels = {
+    "com.example.foo" = "bar"
+  }
+}
+
 resource "container" "consul" {
   image {
     name = "consul:${variable.consul_version}"

--- a/pkg/clients/container/docker_tasks.go
+++ b/pkg/clients/container/docker_tasks.go
@@ -132,6 +132,7 @@ func (d *DockerTasks) CreateContainer(c *dtypes.Container) (string, error) {
 		Domainname:   domain,
 		Image:        c.Image.Name,
 		Env:          env,
+		Labels:       c.Labels,
 		Cmd:          c.Command,
 		Entrypoint:   c.Entrypoint,
 		AttachStdin:  true,

--- a/pkg/clients/container/docker_tasks_container_create_test.go
+++ b/pkg/clients/container/docker_tasks_container_create_test.go
@@ -521,3 +521,16 @@ func TestContainerDropCapabilities(t *testing.T) {
 	assert.Equal(t, "SYS_ADMIN", dc.CapDrop[0])
 	assert.Equal(t, "SYS_CHROOT", dc.CapDrop[1])
 }
+
+func TestContainerLabels(t *testing.T) {
+	cc, md, mic := createContainerConfig()
+	cc.Labels = map[string]string{"com.example.foo": "bar"}
+
+	err := setupContainer(t, cc, md, mic)
+	assert.NoError(t, err)
+
+	params := testutils.GetCalls(&md.Mock, "ContainerCreate")[0].Arguments
+	dc := params[1].(*container.Config)
+	assert.Contains(t, dc.Labels, "com.example.foo")
+	assert.Equal(t, "bar", dc.Labels["com.example.foo"])
+}

--- a/pkg/clients/container/types/types.go
+++ b/pkg/clients/container/types/types.go
@@ -7,6 +7,7 @@ type Container struct {
 	Entrypoint      []string
 	Command         []string
 	Environment     map[string]string
+	Labels          map[string]string
 	Volumes         []Volume
 	Ports           []Port
 	PortRanges      []PortRange

--- a/pkg/config/resources/container/provider.go
+++ b/pkg/config/resources/container/provider.go
@@ -46,6 +46,7 @@ func (p *Provider) Init(cfg htypes.Resource, l logger.Logger) error {
 		co.Volumes = cs.Volumes
 		co.Command = cs.Command
 		co.Entrypoint = cs.Entrypoint
+		co.Labels = cs.Labels
 		co.Environment = cs.Environment
 		co.HealthCheck = cs.HealthCheck
 		co.Image = &cs.Image
@@ -172,6 +173,7 @@ func (c *Provider) internalCreate(sidecar bool) error {
 		Entrypoint:      c.config.Entrypoint,
 		Command:         c.config.Command,
 		Environment:     c.config.Environment,
+		Labels:          c.config.Labels,
 		DNS:             c.config.DNS,
 		Privileged:      c.config.Privileged,
 		MaxRestartCount: c.config.MaxRestartCount,

--- a/pkg/config/resources/container/resource_container.go
+++ b/pkg/config/resources/container/resource_container.go
@@ -22,6 +22,7 @@ type Container struct {
 	Entrypoint      []string            `hcl:"entrypoint,optional" json:"entrypoint,omitempty"`   // Entrypoint to use when starting the container
 	Command         []string            `hcl:"command,optional" json:"command,omitempty"`         // Command to use when starting the container
 	Environment     map[string]string   `hcl:"environment,optional" json:"environment,omitempty"` // Environment variables to set when starting the container
+	Labels          map[string]string   `hcl:"labels,optional" json:"labels,omitempty"`           // Labels to set on the container
 	Volumes         []Volume            `hcl:"volume,block" json:"volumes,omitempty"`             // Volumes to attach to the container
 	Ports           []Port              `hcl:"port,block" json:"ports,omitempty"`                 // Ports to expose
 	PortRanges      []PortRange         `hcl:"port_range,block" json:"port_ranges,omitempty"`     // Range of ports to expose

--- a/pkg/config/resources/container/resource_sidecar.go
+++ b/pkg/config/resources/container/resource_sidecar.go
@@ -21,6 +21,7 @@ type Sidecar struct {
 	Entrypoint  []string          `hcl:"entrypoint,optional" json:"entrypoint,omitempty"`   // entrypoint to use when starting the container
 	Command     []string          `hcl:"command,optional" json:"command,omitempty"`         // command to use when starting the container
 	Environment map[string]string `hcl:"environment,optional" json:"environment,omitempty"` // environment variables to set when starting the container
+	Labels      map[string]string `hcl:"labels,optional" json:"labels,omitempty"`           // labels to set on the container
 	Volumes     []Volume          `hcl:"volume,block" json:"volumes,omitempty"`             // volumes to attach to the container
 
 	Privileged bool `hcl:"privileged,optional" json:"privileged,omitempty"` // run the container in privileged mode?


### PR DESCRIPTION
Allow users to specify a labels map on containers.

e.g.
```hcl
resource "container" "consul_labels" {
  image {
    name = "consul:${variable.consul_version}"
  }

  labels = {
    "com.example.foo" = "bar"
  }
}
```