### PR TITLE
Allow specifying restart count as -1 for always

### DIFF
--- a/pkg/clients/container/docker_tasks.go
+++ b/pkg/clients/container/docker_tasks.go
@@ -149,6 +149,8 @@ func (d *DockerTasks) CreateContainer(c *dtypes.Container) (string, error) {
 
 	if c.MaxRestartCount > 0 {
 		hc.RestartPolicy = container.RestartPolicy{Name: "on-failure", MaximumRetryCount: c.MaxRestartCount}
+	} else if c.MaxRestartCount == -1 {
+		hc.RestartPolicy = container.RestartPolicy{Name: "always"}
 	}
 
 	if c.Capabilities != nil {

--- a/pkg/clients/container/docker_tasks_container_create_test.go
+++ b/pkg/clients/container/docker_tasks_container_create_test.go
@@ -468,6 +468,21 @@ func TestContainerConfiguresRetryWhenCountGreater0(t *testing.T) {
 	assert.Equal(t, hc.RestartPolicy.Name, "on-failure")
 }
 
+func TestContainerConfiguresRetryWhenCountMinusOne(t *testing.T) {
+	cc, md, mic := createContainerConfig()
+	cc.MaxRestartCount = -1
+
+	err := setupContainer(t, cc, md, mic)
+	assert.NoError(t, err)
+
+	params := testutils.GetCalls(&md.Mock, "ContainerCreate")[0].Arguments
+	hc := params[2].(*container.HostConfig)
+	assert.NotEmpty(t, hc.Resources)
+
+	assert.Equal(t, hc.RestartPolicy.MaximumRetryCount, 0)
+	assert.Equal(t, hc.RestartPolicy.Name, "always")
+}
+
 func TestContainerNotConfiguresRetryWhen0(t *testing.T) {
 	cc, md, mic := createContainerConfig()
 

--- a/pkg/config/resources/container/resource_container.go
+++ b/pkg/config/resources/container/resource_container.go
@@ -90,7 +90,7 @@ type Volume struct {
 	ReadOnly                    bool   `hcl:"read_only,optional" json:"read_only,omitempty"`                                           // specify that the volume is mounted read only
 	BindPropagation             string `hcl:"bind_propagation,optional" json:"bind_propagation,omitempty"`                             // propagation mode for bind mounts [shared, private, slave, rslave, rprivate]
 	BindPropagationNonRecursive bool   `hcl:"bind_propagation_non_recursive,optional" json:"bind_propagation_non_recursive,omitempty"` // recursive bind mount, default true
-	SelinuxRelabel              string `hcl:"selinux_relabel,optional" json:"selinux_relabel,optional"`                                // selinux_relabeling ["", shared, private]
+	SelinuxRelabel              string `hcl:"selinux_relabel,optional" json:"selinux_relabel,omitempty"`                               // selinux_relabeling ["", shared, private]
 }
 
 type Volumes []Volume


### PR DESCRIPTION
You can now specify maximum restart count on a container as -1 to always restart a container, instead of having to provide a very large number.

```hcl
resource "container" "consul_disabled" {
  disabled = true

  image {
    name = "consul:${variable.consul_version}"
  }

  max_restart_count = -1
}
```