### PR TITLE
Fix exec to respect shebang for local executed scripts

### DIFF
--- a/pkg/config/resources/exec/provider.go
+++ b/pkg/config/resources/exec/provider.go
@@ -253,8 +253,7 @@ func (p *Provider) createLocalExec() (int, error) {
 
 	// create the config
 	cc := cmdTypes.CommandConfig{
-		Command:          "/bin/sh",
-		Args:             []string{scriptPath},
+		Command:          scriptPath,
 		Env:              envs,
 		WorkingDirectory: p.config.WorkingDirectory,
 		RunInBackground:  p.config.Daemon,


### PR DESCRIPTION
Exec is executing local scripts always with `/bin/sh` letting it ignore script shebang. Instead the script should be executed directly.