### PR TITLE
Fix DOCKER_HOST default to include unix:// path prefix

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -314,7 +314,7 @@ func GetDockerHost() string {
 		return dh
 	}
 
-	return "/var/run/docker.sock"
+	return "unix:///var/run/docker.sock"
 }
 
 // GetDockerIP returns the location of the Docker Server IP address


### PR DESCRIPTION
The default for the `docker_host()` function does not include the `unix://` path prefix. This causes issues when used in exec resources.