### PR TITLE
Use local ips if none are passed in. Use correct port for cert

### DIFF
--- a/cmd/server_certs.go
+++ b/cmd/server_certs.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/jumppad-labs/connector/crypto"
+	"github.com/jumppad-labs/jumppad/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -69,6 +70,10 @@ func newConnectorCertCmd() *cobra.Command {
 				err = k.Private.WriteFile(path.Join(args[0], "leaf.key"))
 				if err != nil {
 					return err
+				}
+
+				if len(ipAddresses) == 0 {
+					ipAddresses = utils.GetLocalIPAddresses()
 				}
 
 				lc, err := crypto.GenerateLeaf("Connector Leaf", ipAddresses, dnsNames, ca, rk.Private, k.Private)

--- a/pkg/clients/connector/connector.go
+++ b/pkg/clients/connector/connector.go
@@ -192,7 +192,7 @@ func (c *ConnectorImpl) GenerateLocalCertBundle(out string) (*types.CertBundle, 
 	}
 
 	grcpParts := strings.Split(c.options.GrpcBind, ":")
-	httpParts := strings.Split(c.options.GrpcBind, ":")
+	httpParts := strings.Split(c.options.HTTPBind, ":")
 
 	ips := utils.GetLocalIPAddresses()
 	host := []string{


### PR DESCRIPTION
When no ip addresses are passed in for the leaf certificate, use the util to determine local ips.

Use correct port for http bind instead of grpc twice in the certificate.