### PR TITLE
Dont render colors in terraform output

### DIFF
--- a/pkg/config/resources/terraform/provider.go
+++ b/pkg/config/resources/terraform/provider.go
@@ -272,12 +272,15 @@ func (p *TerraformProvider) terraformApply(containerid string) error {
 	}
 
 	script := `#!/bin/sh
-	terraform init
+	terraform init \
+		-no-color
 	terraform apply \
+	  -no-color \
 		-state=/var/lib/terraform/terraform.tfstate \
 		-var-file=/var/lib/terraform/terraform.tfvars \
 		-auto-approve
 	terraform output \
+		-no-color \
 		-state=/var/lib/terraform/terraform.tfstate \
 		-json > /var/lib/terraform/output.json`
 
@@ -372,8 +375,10 @@ func (p *TerraformProvider) terraformDestroy(containerid string) error {
 	wd := path.Join("/config", p.config.WorkingDirectory)
 
 	script := `#!/bin/sh
-	terraform init
+	terraform init \
+		-no-color
 	terraform destroy \
+		-no-color \
 		-state=/var/lib/terraform/terraform.tfstate \
 		-var-file=/var/lib/terraform/terraform.tfvars \
 		-auto-approve


### PR DESCRIPTION
When outputting jumppad output to logs and showing terraform output using LOG_LEVEL=debug, the logs will contain many escaped color escape codes. This makes it hard to read the logs.