### PR TITLE
Add GPU resources

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,30 @@
 # Change Log
 
-## version v0.10.1
-* Ensure that the total compute is set correctly	for Nomad clusters when 
-	running on Docker in Apple Silicon.
+## version v0.10.4
+
+## New Features:
+Enable experimental support for nvidia GPUs for container resources
+
+This feature configures the container to use the nvidia runtime and the nvidia
+device plugin to access the GPU.  Currently this has only been tested with WSL2 and
+Nvidia GPUs.
+
+```hcl
+resource "container" "gpu_test" {
+  image {
+    name = "nvcr.io/nvidia/k8s/cuda-sample:nbody"
+  }
+
+  command = ["nbody", "-gpu", "-benchmark"]
+
+  resources {
+    gpu {
+      driver     = "nvidia"
+      device_ids = ["0"]
+    }
+  }
+}
+```
 
 ## version v0.10.0
 

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -25,9 +25,33 @@ var changelogCmd = &cobra.Command{
 	},
 }
 
-var changesVersion = "v0.10.0"
+var changesVersion = "v0.10.4"
 
 var changes = `
+## version v0.10.4
+Enable experimental support for nvidia GPUs for container resources
+
+This feature configures the container to use the nvidia runtime and the nvidia
+device plugin to access the GPU.  Currently this has only been tested with WSL2 and
+Nvidia GPUs.
+
+"""hcl
+resource "container" "gpu_test" {
+  image {
+    name = "nvcr.io/nvidia/k8s/cuda-sample:nbody"
+  }
+
+  command = ["nbody", "-gpu", "-benchmark"]
+
+  resources {
+    gpu {
+      driver     = "nvidia"
+      device_ids = ["0"]
+    }
+  }
+}
+"""
+
 ## version v0.10.1
 * Ensure that the total compute is set correctly	for Nomad clusters when 
 	running on Docker in Apple Silicon.
@@ -109,120 +133,4 @@ output "KUBE_CLIENT_KEY" {
   value = resource.k8s_cluster.k3s.kube_config.client_key
 }
 """
-
-## version v0.9.1
-* Update internal references to use the new 'local.jmpd.in' domain bypassing
-  problems where chrome auto redirects .dev to https://.
-* Update Nomad to 1.7.5
-
-## version v0.7.0
-
-### Breaking Changes:
-This version of Jumppad introduces experimental plugin support for custom resources. 
-To avoid conflicts between the default properties and the custom properties 
-the default properties for a resource have been renamed to prefix "resource_" 
-to their name. For example previously to reference the "id" of a resource you could write:
-
-"""
-resource.container.mine.id
-"""
-
-This has now changed to:
-
-"""
-resource.container.mine.meta.id
-"""
-
-From this version onwards the old property names are no longer be supported 
-and you may need to update your configuration.
-
-The full list of properties tha have been changed are:
-
-| Old Property Name | New Property Name   |
-|-------------------|---------------------|
-| id                | meta.id         |
-| name              | meta.name       |
-| type              | meta.type       |
-| module            | resource_module     |
-| file              | resource_file       |
-| line              | resource_line       |
-| column            | resource_column     |
-| checksum          | resource_checksum   |
-| checksum          | resource_checksum   |
-| properties        | resource_properties |
-
-### Features:
-* Add capability to add custom container registries to the image cache  
-
-Nomad and Kuberentes clusters are started in a Docker container that does not save any state to the local disk.
-This state includes and Docker Image cache, thefore every time an image is pulled to a new cluster it is downloaded
-from the internet. This can be slow and bandwidth intensive. To solve this problem Jumppad implemented a pull through
-cache that is used by all clusters. By default this cache supported the following registires:  
-
-  - k8s.gcr.io 
-  - gcr.io 
-  - asia.gcr.io
-  - eu.gcr.io
-  - us.gcr.io 
-  - quay.io
-  - ghcr.io
-  - docker.pkg.github.com
-  
-To support custom registries Jumppad has added a new resource type "container_registry". This resource type can be used
-to define either a local or remote registry. When a registry is defined it is added to the pull through cache and
-any authnetication details are added to the cache meaning you do not need to authenticate each pull on the Nomad or 
-Kubernetes cluster. Any defined registry must be configured to use HTTPS, the image cache can not be used to pull
-from insecure registries.
-
-"""hcl
-# Define a custom registry that does not use authentication
-resource "container_registry" "noauth" {
-  hostname = "noauth-registry.demo.gs" // cache can not resolve local.jmpd.in dns for some reason, 
-                                       // using external dns mapped to the local ip address
-}
-
-# Define a custom registry that uses authentication
-resource "container_registry" "auth" {
-  hostname = "auth-registry.demo.gs"
-  auth {
-    username = "admin"
-    password = "password"
-  }
-}
-"""
-
-* Add capability to add insecure registries and image cache bypass to Kubernetes and Nomad clusters.
-  
-All images pulled to Nomad and Kubernetes clusters are pulled through the image cache. This cache is a Docker
-container that is automatically started by Jumppad. To disable the cache and pull images directly from the internet
-you can add the "no_proxy" parameter to the new docker config stanza. This will cause the cache to be bypassed and
-the image to be pulled direct from the internet.  
-
-To support insecure registries you can add the "insecure_registries" parameter to the docker config stanza. This
-must be used in conjunction with the "no_proxy" parameter as the image cache does not support insecure registries. 
-
-"""hcl
-resource "nomad_cluster" "dev" {
-  client_nodes = 1
-
-  datacenter = "dc1"
-
-  network {
-    id = variable.network_id
-  }
-
-  // add configuration to allow cache bypass and insecure registry
-  config {
-    docker {
-      no_proxy            = ["insecure.container.jmpd.in"]
-      insecure_registries = ["insecure.container.jmpd.in:5003"]
-    }
-  }
-}
-"""
-
-## version v0.5.47
-* Fix isuse where filepath.Walk does not respect symlinks
-* Add "ignore" parameter to "build" resource to allow ignoring of files and folders
-  for Docker builds.
-	`
+`

--- a/pkg/clients/container/docker_tasks.go
+++ b/pkg/clients/container/docker_tasks.go
@@ -187,18 +187,19 @@ func (d *DockerTasks) CreateContainer(c *dtypes.Container) (string, error) {
 		}
 
 		hc.Resources = rc
+
+		if c.Resources.GPU != nil {
+			hc.DeviceRequests = []container.DeviceRequest{
+				{
+					Driver:       c.Resources.GPU.Driver,
+					DeviceIDs:    c.Resources.GPU.DeviceIDs,
+					Capabilities: [][]string{[]string{"gpu", c.Resources.GPU.Driver, "compute"}},
+				},
+			}
+		}
 	}
 
 	// Add GPU details
-	if c.Resources.GPU != nil {
-		hc.DeviceRequests = []container.DeviceRequest{
-			{
-				Driver:       c.Resources.GPU.Driver,
-				DeviceIDs:    c.Resources.GPU.DeviceIDs,
-				Capabilities: [][]string{[]string{"gpu", c.Resources.GPU.Driver, "compute"}},
-			},
-		}
-	}
 
 	// by default the container should NOT be attached to a network
 	nc.EndpointsConfig = make(map[string]*network.EndpointSettings)

--- a/pkg/clients/container/docker_tasks.go
+++ b/pkg/clients/container/docker_tasks.go
@@ -189,6 +189,17 @@ func (d *DockerTasks) CreateContainer(c *dtypes.Container) (string, error) {
 		hc.Resources = rc
 	}
 
+	// Add GPU details
+	if c.Resources.GPU != nil {
+		hc.DeviceRequests = []container.DeviceRequest{
+			{
+				Driver:       c.Resources.GPU.Driver,
+				DeviceIDs:    c.Resources.GPU.DeviceIDs,
+				Capabilities: [][]string{[]string{"gpu", c.Resources.GPU.Driver, "compute"}},
+			},
+		}
+	}
+
 	// by default the container should NOT be attached to a network
 	nc.EndpointsConfig = make(map[string]*network.EndpointSettings)
 

--- a/pkg/clients/container/types/types.go
+++ b/pkg/clients/container/types/types.go
@@ -49,6 +49,12 @@ type Resources struct {
 	CPU    int
 	CPUPin []int
 	Memory int
+	GPU    *GPU
+}
+
+type GPU struct {
+	Driver    string
+	DeviceIDs []string
 }
 
 // Volume defines a folder, Docker volume, or temp folder to mount to the Container

--- a/pkg/config/resources/container/provider.go
+++ b/pkg/config/resources/container/provider.go
@@ -248,10 +248,13 @@ func (c *Provider) internalCreate(ctx context.Context, sidecar bool) error {
 			CPU:    c.config.Resources.CPU,
 			CPUPin: c.config.Resources.CPUPin,
 			Memory: c.config.Resources.Memory,
-			GPU: &types.GPU{
+		}
+
+		if c.config.Resources.GPU != nil {
+			new.Resources.GPU = &types.GPU{
 				Driver:    c.config.Resources.GPU.Driver,
 				DeviceIDs: c.config.Resources.GPU.DeviceIDs,
-			},
+			}
 		}
 	}
 

--- a/pkg/config/resources/container/provider.go
+++ b/pkg/config/resources/container/provider.go
@@ -248,6 +248,10 @@ func (c *Provider) internalCreate(ctx context.Context, sidecar bool) error {
 			CPU:    c.config.Resources.CPU,
 			CPUPin: c.config.Resources.CPUPin,
 			Memory: c.config.Resources.Memory,
+			GPU: &types.GPU{
+				Driver:    c.config.Resources.GPU.Driver,
+				DeviceIDs: c.config.Resources.GPU.DeviceIDs,
+			},
 		}
 	}
 

--- a/pkg/config/resources/container/provider_test.go
+++ b/pkg/config/resources/container/provider_test.go
@@ -1,12 +1,12 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/jumppad-labs/hclconfig/types"
-	"github.com/jumppad-labs/jumppad/pkg/clients"
 	"github.com/jumppad-labs/jumppad/pkg/clients/container/mocks"
 	ctypes "github.com/jumppad-labs/jumppad/pkg/clients/container/types"
 	hmocks "github.com/jumppad-labs/jumppad/pkg/clients/http/mocks"
@@ -19,7 +19,7 @@ import (
 
 func setupContainerTests(t *testing.T) (*Container, *mocks.ContainerTasks, *hmocks.HTTP) {
 	cc := &Container{ResourceBase: types.ResourceBase{
-		Name: "tests",
+		Meta: types.Meta{Name: "tests", Type: TypeContainer},
 	}}
 
 	cc.Image = &Image{Name: "consul"}
@@ -28,13 +28,13 @@ func setupContainerTests(t *testing.T) (*Container, *mocks.ContainerTasks, *hmoc
 	hc := &hmocks.HTTP{}
 
 	// check pulls image before creating container
-	md.On("PullImage", *cc.Image, false).Once().Return(nil)
+	md.On("PullImage", ctypes.Image{Name: cc.Image.Name, Username: cc.Image.Username, Password: cc.Image.Password}, false).Once().Return(nil)
 
 	// fetches the id of the pulled image, this is used to detect changes
-	md.On("FindImageInLocalRegistry", *cc.Image).Once().Return("myimage", nil)
+	md.On("FindImageInLocalRegistry", ctypes.Image{Name: cc.Image.Name, Username: cc.Image.Username, Password: cc.Image.Password}).Once().Return("myimage", nil)
 
 	// check calls CreateContainer with the config
-	md.On("CreateContainer", cc).Once().Return("12345", nil)
+	md.On("CreateContainer", mock.Anything).Once().Return("12345", nil)
 
 	// after creation the
 	md.On("ListNetworks", "12345").Once().Return(nil, nil)
@@ -54,15 +54,15 @@ func TestContainerCreatesSuccessfully(t *testing.T) {
 }
 
 func TestContainerSidecarCreatesContainerSuccessfully(t *testing.T) {
-	_, md, hc := setupContainerTests(t)
+	c, md, hc := setupContainerTests(t)
 	testutils.RemoveOn(&md.Mock, "CreateContainer")
 	md.On("CreateContainer", mock.Anything).Once().Return("12345", nil)
 
 	cs := &Sidecar{ResourceBase: types.ResourceBase{
-		Name: "tests",
+		Meta: types.Meta{Name: "tests", Type: TypeSidecar},
 	}}
 
-	cs.Target = "resources.container.consul"
+	cs.Target = *c
 	cs.Volumes = []Volume{Volume{}}
 	cs.Command = []string{"hello"}
 	cs.Entrypoint = []string{"hello"}
@@ -70,24 +70,39 @@ func TestContainerSidecarCreatesContainerSuccessfully(t *testing.T) {
 	cs.HealthCheck = &healthcheck.HealthCheckContainer{}
 	cs.Image = Image{Name: "consul"}
 	cs.Privileged = true
-	cs.Resources = &Resources{}
+	cs.Resources = &Resources{CPU: 1}
 	cs.MaxRestartCount = 10
 
-	c := Provider(cs, md, hc, clients.NewTestLogger(t))
-	err := c.Create(context.Background())
+	co := &Container{}
+	co.ResourceBase = cs.ResourceBase
+	co.ContainerName = cs.ContainerName
+
+	co.Networks = []NetworkAttachment{{ID: "tests.container.local.jmpd.in"}}
+	co.Volumes = cs.Volumes
+	co.Command = cs.Command
+	co.Entrypoint = cs.Entrypoint
+	co.Labels = cs.Labels
+	co.Environment = cs.Environment
+	co.HealthCheck = cs.HealthCheck
+	co.Image = &cs.Image
+	co.Privileged = cs.Privileged
+	co.Resources = cs.Resources
+	co.MaxRestartCount = cs.MaxRestartCount
+
+	p := Provider{config: co, sidecar: cs, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
+	err := p.Create(context.Background())
 	assert.NoError(t, err)
 
 	ac := testutils.GetCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*ctypes.Container)
 
-	assert.Equal(t, cs.Name, ac.Name)
-	assert.Equal(t, "resources.container.consul", ac.Networks[0].ID)
-	assert.Equal(t, cs.Volumes, ac.Volumes)
+	assert.Equal(t, "tests.sidecar.local.jmpd.in", ac.Name)
+	assert.Equal(t, "tests.container.local.jmpd.in", ac.Networks[0].ID)
 	assert.Equal(t, cs.Command, ac.Command)
 	assert.Equal(t, cs.Entrypoint, ac.Entrypoint)
 	assert.Equal(t, cs.Environment, ac.Environment)
-	assert.Equal(t, &cs.Image, ac.Image)
+	assert.Equal(t, cs.Image.Name, ac.Image.Name)
 	assert.Equal(t, cs.Privileged, ac.Privileged)
-	assert.Equal(t, cs.Resources, ac.Resources)
+	assert.Equal(t, cs.Resources.CPU, ac.Resources.CPU)
 	assert.Equal(t, cs.MaxRestartCount, ac.MaxRestartCount)
 }
 
@@ -101,14 +116,14 @@ func TestContainerRunsHTTPChecks(t *testing.T) {
 		}},
 	}
 
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
-	hc.On("HealthCheckHTTP", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	hc.On("HealthCheckHTTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	err := c.Create(context.Background())
+	err := p.Create(context.Background())
 	assert.NoError(t, err)
 
-	hc.AssertCalled(t, "HealthCheckHTTP", "http://localhost:8500", []int{200, 429}, 30*time.Second)
+	hc.AssertCalled(t, "HealthCheckHTTP", "http://localhost:8500", "", mock.Anything, mock.Anything, []int{200, 429}, 30*time.Second)
 }
 
 func TestContainerRunsTCPChecks(t *testing.T) {
@@ -120,11 +135,11 @@ func TestContainerRunsTCPChecks(t *testing.T) {
 		}},
 	}
 
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
-	hc.On("HealthCheckTCP", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	hc.On("HealthCheckTCP", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	err := c.Create(context.Background())
+	err := p.Create(context.Background())
 	assert.NoError(t, err)
 
 	hc.AssertCalled(t, "HealthCheckTCP", "http://localhost:8500", 30*time.Second)
@@ -142,9 +157,9 @@ func TestContainerRunsExecChecksWithCommand(t *testing.T) {
 
 	md.On("ExecuteCommand", "12345", command, mock.Anything, "/tmp", "", "", 30, mock.Anything).Return(0, nil)
 
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
-	err := c.Create(context.Background())
+	err := p.Create(context.Background())
 	assert.NoError(t, err)
 
 	md.AssertNumberOfCalls(t, "ExecuteCommand", 1)
@@ -164,9 +179,9 @@ func TestContainerRunsExecChecksWithScript(t *testing.T) {
 	md.On("CopyFileToContainer", "12345", mock.Anything, mock.Anything).Return(nil)
 	md.On("ExecuteCommand", "12345", []string{"sh", "/tmp/script.sh"}, mock.Anything, "/tmp", "", "", 30, mock.Anything).Return(0, nil)
 
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
-	err := c.Create(context.Background())
+	err := p.Create(context.Background())
 	assert.NoError(t, err)
 
 	md.AssertNumberOfCalls(t, "ExecuteCommand", 1)
@@ -174,41 +189,41 @@ func TestContainerRunsExecChecksWithScript(t *testing.T) {
 
 func TestContainerDoesNOTCreateWhenPullImageFail(t *testing.T) {
 	cc, md, hc := setupContainerTests(t)
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
 	// check pulls image before creating container and return an erro
 	testutils.RemoveOn(&md.Mock, "PullImage")
 	imageErr := fmt.Errorf("Unable to pull image")
-	md.On("PullImage", *cc.Image, false).Once().Return(imageErr)
+	md.On("PullImage", ctypes.Image{Name: cc.Image.Name}, false).Once().Return(imageErr)
 
 	// check does not call CreateContainer with the config
 	md.On("CreateContainer", cc).Times(0)
 
-	err := c.Create(context.Background())
+	err := p.Create(context.Background())
 	assert.Equal(t, imageErr, err)
 }
 
 func TestContainerDestroysCorrectlyWhenContainerExists(t *testing.T) {
 	cc, md, hc := setupContainerTests(t)
 	cc.Networks = []NetworkAttachment{NetworkAttachment{Name: "cloud"}}
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
 	md.On("FindContainerIDs", cc.ContainerName).Return([]string{"abc"}, nil)
 	md.On("RemoveContainer", "abc", false).Return(nil)
 	md.On("DetachNetwork", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	err := c.Destroy(context.Background(),false)
+	err := p.Destroy(context.Background(), false)
 	assert.NoError(t, err)
 }
 
 func TestContainerDoesNotDestroysWhenNotExists(t *testing.T) {
 	cc, md, hc := setupContainerTests(t)
 	cc.Networks = []NetworkAttachment{NetworkAttachment{Name: "cloud"}}
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
 	md.On("FindContainerIDs", cc.ContainerName).Return(nil, nil)
 
-	err := c.Destroy(context.Background(),false)
+	err := p.Destroy(context.Background(), false)
 	assert.NoError(t, err)
 	md.AssertNotCalled(t, "RemoveContainer")
 }
@@ -216,11 +231,11 @@ func TestContainerDoesNotDestroysWhenNotExists(t *testing.T) {
 func TestContainerDoesNotDestroysWhenLookupError(t *testing.T) {
 	cc, md, hc := setupContainerTests(t)
 	cc.Networks = []NetworkAttachment{NetworkAttachment{Name: "cloud"}}
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
 	md.On("FindContainerIDs", cc.ContainerName).Return(nil, fmt.Errorf("boom"))
 
-	err := c.Destroy(context.Background(),false)
+	err := p.Destroy(context.Background(), false)
 	assert.Error(t, err)
 	md.AssertNotCalled(t, "RemoveContainer")
 }
@@ -228,11 +243,35 @@ func TestContainerDoesNotDestroysWhenLookupError(t *testing.T) {
 func TestContainerLooksupIDs(t *testing.T) {
 	cc, md, hc := setupContainerTests(t)
 	cc.Networks = []NetworkAttachment{NetworkAttachment{Name: "cloud"}}
-	c := NewContainerProvider(cc, md, hc, clients.NewTestLogger(t))
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
 
 	md.On("FindContainerIDs", cc.ContainerName).Return([]string{"abc"}, nil)
 
-	ids, err := c.Lookup()
+	ids, err := p.Lookup()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"abc"}, ids)
+}
+
+func TestContainerAddsResources(t *testing.T) {
+	cc, md, hc := setupContainerTests(t)
+	cc.Networks = []NetworkAttachment{NetworkAttachment{Name: "cloud"}}
+	cc.Resources = &Resources{
+		CPU:    1,
+		CPUPin: []int{1},
+		Memory: 1,
+		GPU: &GPU{
+			Driver:    "nvidia",
+			DeviceIDs: []string{"1"},
+		},
+	}
+
+	p := Provider{config: cc, client: md, httpClient: hc, log: logger.NewTestLogger(t)}
+	p.Create(context.Background())
+
+	ac := testutils.GetCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*ctypes.Container)
+	assert.Equal(t, 1, ac.Resources.CPU)
+	assert.Equal(t, 1, ac.Resources.Memory)
+	assert.Equal(t, []int{1}, ac.Resources.CPUPin)
+	assert.Equal(t, "nvidia", ac.Resources.GPU.Driver)
+	assert.Equal(t, []string{"1"}, ac.Resources.GPU.DeviceIDs)
 }

--- a/pkg/config/resources/container/resource_container.go
+++ b/pkg/config/resources/container/resource_container.go
@@ -76,6 +76,12 @@ type Resources struct {
 	CPU    int   `hcl:"cpu,optional" json:"cpu,omitempty"`         // cpu limit for the container where 1 CPU = 1000
 	CPUPin []int `hcl:"cpu_pin,optional" json:"cpu_pin,omitempty"` // pin the container to one or more cpu cores
 	Memory int   `hcl:"memory,optional" json:"memory,omitempty"`   // max memory the container can consume in MB
+	GPU    *GPU  `hcl:"gpu,block" json:"gpu,omitempty"`            // GPU resource constraints
+}
+
+type GPU struct {
+	Driver    string   `hcl:"driver" json:"driver"`         // driver to use for the GPU
+	DeviceIDs []string `hcl:"device_ids" json:"device_ids"` // device ids to use for the GPU
 }
 
 type Capabilities struct {


### PR DESCRIPTION
## version v0.10.4
Enable experimental support for nvidia GPUs for container resources

This feature configures the container to use the nvidia runtime and the nvidia
device plugin to access the GPU.  Currently this has only been tested with WSL2 and
Nvidia GPUs.

```hcl
resource "container" "gpu_test" {
  image {
    name = "nvcr.io/nvidia/k8s/cuda-sample:nbody"
  }

  command = ["nbody", "-gpu", "-benchmark"]

  resources {
    gpu {
      driver     = "nvidia"
      device_ids = ["0"]
    }
  }
}
```