### PR TITLE
Add GPU resources for containers and output variables for exec

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## version v0.10.5
+
+## New Features:
+Adds outputs for `exec` resources
+
+Exec resources now have a new parameter `output` which is a map of key value pairs.
+Values for output can be set by echoing a key value to the file `${EXEC_OUTPUT}` in 
+the defined script for either remote or local exec.
+
+```hcl
+resource "exec" "install" {
+  # Add the output
+  echo "exec=install" >> $EXEC_OUTPUT
+  echo "foo=bar" >> $EXEC_OUTPUT
+  EOF
+
+  timeout = "30s"
+}
+
+output "local_exec_install" {
+  value = resource.exec.install.output.exec
+}
+```
+
 ## version v0.10.4
 
 ## New Features:

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -25,9 +25,33 @@ var changelogCmd = &cobra.Command{
 	},
 }
 
-var changesVersion = "v0.10.4"
+var changesVersion = "v0.10.5"
 
 var changes = `
+## version v0.10.5
+
+## New Features:
+Adds outputs for 'exec' resources
+
+Exec resources now have a new parameter 'output' which is a map of key value pairs.
+Values for output can be set by echoing a key value to the file '${EXEC_OUTPUT}' in 
+the defined script for either remote or local exec.
+
+"""hcl
+resource "exec" "install" {
+  # Add the output
+  echo "exec=install" >> $EXEC_OUTPUT
+  echo "foo=bar" >> $EXEC_OUTPUT
+  EOF
+
+  timeout = "30s"
+}
+
+output "local_exec_install" {
+  value = resource.exec.install.output.exec
+}
+"""
+
 ## version v0.10.4
 Enable experimental support for nvidia GPUs for container resources
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -60,6 +60,7 @@ func newDestroyCmd(cc connector.Connector, l logger.Logger) *cobra.Command {
 			// clean up the data folders
 			os.RemoveAll(utils.DataFolder("", os.ModePerm))
 			os.RemoveAll(utils.LibraryFolder("", os.ModePerm))
+			os.RemoveAll(utils.JumppadTemp())
 
 			// shutdown ingress when we destroy all resources
 			if cc.IsRunning() {

--- a/cmd/plugin_build.go
+++ b/cmd/plugin_build.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jumppad-labs/hclconfig/types"
 	"github.com/jumppad-labs/jumppad/pkg/clients"
 	"github.com/jumppad-labs/jumppad/pkg/config/resources/build"
+	"github.com/jumppad-labs/jumppad/pkg/utils"
 	cp "github.com/otiai10/copy"
 	"github.com/spf13/cobra"
 	"golang.org/x/mod/modfile"
@@ -64,7 +65,7 @@ var pluginCmd = &cobra.Command{
 		engineClients, _ := clients.GenerateClients(l)
 
 		// create a temp output folder
-		tmp := os.TempDir()
+		tmp := utils.JumppadTemp()
 		output := filepath.Join(tmp, "jumppad_build")
 
 		os.RemoveAll(output)

--- a/examples/exec/local.hcl
+++ b/examples/exec/local.hcl
@@ -11,7 +11,9 @@ resource "exec" "install" {
   curl -L -o ${data("test")}/consul.zip https://releases.hashicorp.com/consul/1.16.2/consul_1.16.2_$${OS}_$${ARCH}.zip
   cd ${data("test")} && unzip ./consul.zip
 
-  echo "TEST=
+  # Add the output
+  echo "$EXEC_OUTPUT" >> /tmp/output.var
+  echo "exec=install" >> $EXEC_OUTPUT
   EOF
 
   timeout = "30s"
@@ -23,7 +25,18 @@ resource "exec" "run" {
   script = <<-EOF
   #!/bin/sh
   ${data("test")}/consul agent -dev
+  
+  # We will never get here as the previous command blocks
+  echo "exec=run" >> $EXEC_OUTPUT
   EOF
 
   daemon = true
 }
+
+output "local_exec_install" {
+  value = resource.exec.install.output.exec
+}
+
+//output "local_exec_run" {
+//  value = resource.exec.run.output.exec
+//}

--- a/examples/exec/local.hcl
+++ b/examples/exec/local.hcl
@@ -12,7 +12,6 @@ resource "exec" "install" {
   cd ${data("test")} && unzip ./consul.zip
 
   # Add the output
-  echo "$EXEC_OUTPUT" >> /tmp/output.var
   echo "exec=install" >> $EXEC_OUTPUT
   EOF
 

--- a/examples/exec/remote.hcl
+++ b/examples/exec/remote.hcl
@@ -18,6 +18,8 @@ resource "exec" "in_container" {
   #!/bin/sh -e
 
   touch /data/container.txt
+
+  echo "exec=container" >> $EXEC_OUTPUT
   EOF
 }
 
@@ -30,10 +32,20 @@ resource "exec" "standalone" {
   #!/bin/sh -e
 
   touch /data/standalone.txt
+  
+  echo "exec=standalone" >> $EXEC_OUTPUT
   EOF
 
   volume {
     source      = data("test")
     destination = "/data"
   }
+}
+
+output "remote_exec_container" {
+  value = resource.exec.in_container.output.exec
+}
+
+output "remote_exec_standalone" {
+  value = resource.exec.standalone.output.exec
 }

--- a/pkg/clients/command/command.go
+++ b/pkg/clients/command/command.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/jumppad-labs/gohup"
 	"github.com/jumppad-labs/jumppad/pkg/clients/command/types"
 	"github.com/jumppad-labs/jumppad/pkg/clients/logger"
+	"github.com/jumppad-labs/jumppad/pkg/utils"
 )
 
 var ErrorCommandTimeout = fmt.Errorf("Command timed out before completing")
@@ -122,7 +122,7 @@ func (c *CommandImpl) Execute(config types.CommandConfig) (int, error) {
 // Kill a process with the given pid
 func (c *CommandImpl) Kill(pid int) error {
 	lp := gohup.LocalProcess{}
-	pidPath := filepath.Join(os.TempDir(), fmt.Sprintf("%d.pid", pid))
+	pidPath := filepath.Join(utils.JumppadTemp(), fmt.Sprintf("%d.pid", pid))
 
 	if s, _ := lp.QueryStatus(pidPath); s == gohup.StatusRunning {
 		return lp.Stop(pidPath)

--- a/pkg/clients/container/docker_tasks.go
+++ b/pkg/clients/container/docker_tasks.go
@@ -741,7 +741,7 @@ func (d *DockerTasks) CopyFromContainer(id, src, dst string) error {
 	defer reader.Close()
 
 	// untar the file to a temporary folder
-	dir, err := os.MkdirTemp(os.TempDir(), "")
+	dir, err := os.MkdirTemp(utils.JumppadTemp(), id)
 	if err != nil {
 		return fmt.Errorf("unable to create temporary directory, %s", err)
 	}
@@ -968,7 +968,7 @@ func (d *DockerTasks) CopyFilesToVolume(volumeID string, filenames []string, pat
 // CreateFileInContainer creates a file with the given contents and name in the container containerID and
 // stores it in the container at the directory path.
 func (d *DockerTasks) CreateFileInContainer(containerID, contents, filename, path string) error {
-	tmpFile := filepath.Join(os.TempDir(), filename)
+	tmpFile := filepath.Join(utils.JumppadTemp(), filename)
 
 	err := os.WriteFile(tmpFile, []byte(contents), 0755)
 	if err != nil {

--- a/pkg/config/resources/container/provider.go
+++ b/pkg/config/resources/container/provider.go
@@ -340,7 +340,7 @@ func (c *Provider) internalCreate(ctx context.Context, sidecar bool) error {
 func (c *Provider) runExecHealthCheck(ctx context.Context, id string, command []string, script string, exitCode int, timeout time.Duration) error {
 	if len(script) > 0 {
 		// write the script to a temp file
-		dir, err := os.MkdirTemp(os.TempDir(), "script*")
+		dir, err := os.MkdirTemp(utils.JumppadTemp(), "script*")
 		if err != nil {
 			return fmt.Errorf("unable to create temporary directory for script: %s", err)
 		}

--- a/pkg/config/resources/exec/provider.go
+++ b/pkg/config/resources/exec/provider.go
@@ -61,7 +61,7 @@ func (p *Provider) Create(ctx context.Context) error {
 
 	p.log.Info("executing script", "ref", p.config.Meta.ID, "script", p.config.Script)
 
-	outPath := fmt.Sprintf("%s/%s.out", os.TempDir(), p.config.Meta.ID)
+	outPath := fmt.Sprintf("%s/%s.out", utils.JumppadTemp(), p.config.Meta.ID)
 
 	// cleanup the local output file
 	defer os.Remove(outPath)

--- a/pkg/config/resources/exec/provider_test.go
+++ b/pkg/config/resources/exec/provider_test.go
@@ -1,0 +1,106 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jumppad-labs/hclconfig/types"
+	commandMocks "github.com/jumppad-labs/jumppad/pkg/clients/command/mocks"
+	cmdTypes "github.com/jumppad-labs/jumppad/pkg/clients/command/types"
+	containerMocks "github.com/jumppad-labs/jumppad/pkg/clients/container/mocks"
+	"github.com/jumppad-labs/jumppad/pkg/clients/logger"
+	"github.com/jumppad-labs/jumppad/pkg/config/resources/container"
+	"github.com/jumppad-labs/jumppad/testutils"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func setupProvider(t *testing.T) (*Exec, *Provider, *commandMocks.Command, *containerMocks.ContainerTasks) {
+	cm := &commandMocks.Command{}
+	cm.On("Execute", mock.Anything).Return(1, nil)
+
+	dm := &containerMocks.ContainerTasks{}
+	dm.On("FindContainerIDs", mock.Anything).Return([]string{"abc123"}, nil)
+	dm.On("ExecuteScript", "abc123", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
+	dm.On("CopyFromContainer", "abc123", mock.Anything, mock.Anything).Return(nil)
+	dm.On("ExecuteCommand", "abc123", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
+
+	e := &Exec{ResourceBase: types.ResourceBase{Meta: types.Meta{Name: "test", ID: "resource.exec.test"}}}
+	p := &Provider{config: e, log: logger.NewTestLogger(t), command: cm, container: dm}
+
+	return e, p, cm, dm
+}
+
+func TestInjectsOutputEnvIntoLocal(t *testing.T) {
+	e, p, cm, _ := setupProvider(t)
+	e.Script = "echo FOO=BAR >> $EXEC_OUTPUT"
+
+	err := p.Create(context.Background())
+	require.NoError(t, err)
+
+	ac := testutils.GetCalls(&cm.Mock, "Execute")[0].Arguments[0].(cmdTypes.CommandConfig)
+
+	td := os.TempDir()
+	require.Contains(t, ac.Env, fmt.Sprintf("EXEC_OUTPUT=%s/resource.exec.test.out", td))
+}
+
+func TestParsesOutput(t *testing.T) {
+	e, p, _, _ := setupProvider(t)
+	e.Script = "echo FOO=BAR >> $EXEC_OUTPUT"
+
+	// write the output for the test
+	td := os.TempDir()
+	os.WriteFile(fmt.Sprintf("%s/resource.exec.test.out", td), []byte("FOO=BAR"), 0644)
+	t.Cleanup(func() {
+		os.Remove(fmt.Sprintf("%s/resource.exec.test.out", td))
+	})
+
+	err := p.Create(context.Background())
+	require.NoError(t, err)
+
+	require.True(t, e.Output["FOO"] == "BAR")
+}
+
+func TestDeletesOutput(t *testing.T) {
+	e, p, _, _ := setupProvider(t)
+	e.Script = "echo FOO=BAR >> $EXEC_OUTPUT"
+
+	// write the output for the test
+	td := os.TempDir()
+	os.WriteFile(fmt.Sprintf("%s/resource.exec.test.out", td), []byte("FOO=BAR"), 0644)
+
+	err := p.Create(context.Background())
+	require.NoError(t, err)
+
+	require.NoFileExists(t, fmt.Sprintf("%s/resource.exec.test.out", td))
+}
+
+func TestCopiesOutputInExec(t *testing.T) {
+	c := &container.Container{ResourceBase: types.ResourceBase{Meta: types.Meta{Name: "test", ID: "container.exec.test"}}}
+
+	e, p, _, dm := setupProvider(t)
+	e.Target = c
+	e.Script = "echo FOO=BAR >> $EXEC_OUTPUT"
+
+	// write the output for the test
+	td := os.TempDir()
+	os.WriteFile(fmt.Sprintf("%s/resource.exec.test.out", td), []byte("FOO=BAR"), 0644)
+	t.Cleanup(func() {
+		os.Remove(fmt.Sprintf("%s/resource.exec.test.out", td))
+	})
+
+	err := p.Create(context.Background())
+	require.NoError(t, err)
+
+	// test copies file
+	cp := testutils.GetCalls(&dm.Mock, "CopyFromContainer")[0].Arguments
+	require.Equal(t, "abc123", cp[0].(string))
+	require.Equal(t, "/tmp/exec.out", cp[1].(string))
+	require.Equal(t, fmt.Sprintf("%s/resource.exec.test.out", td), cp[2].(string))
+
+	// test cleans up file
+	rm := testutils.GetCalls(&dm.Mock, "ExecuteCommand")[0].Arguments[1].([]string)
+	require.Equal(t, []string{"rm", "/tmp/exec.out"}, rm)
+}

--- a/pkg/config/resources/exec/provider_test.go
+++ b/pkg/config/resources/exec/provider_test.go
@@ -12,6 +12,7 @@ import (
 	containerMocks "github.com/jumppad-labs/jumppad/pkg/clients/container/mocks"
 	"github.com/jumppad-labs/jumppad/pkg/clients/logger"
 	"github.com/jumppad-labs/jumppad/pkg/config/resources/container"
+	"github.com/jumppad-labs/jumppad/pkg/utils"
 	"github.com/jumppad-labs/jumppad/testutils"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestInjectsOutputEnvIntoLocal(t *testing.T) {
 
 	ac := testutils.GetCalls(&cm.Mock, "Execute")[0].Arguments[0].(cmdTypes.CommandConfig)
 
-	td := os.TempDir()
+	td := utils.JumppadTemp()
 	require.Contains(t, ac.Env, fmt.Sprintf("EXEC_OUTPUT=%s/resource.exec.test.out", td))
 }
 
@@ -51,7 +52,8 @@ func TestParsesOutput(t *testing.T) {
 	e.Script = "echo FOO=BAR >> $EXEC_OUTPUT"
 
 	// write the output for the test
-	td := os.TempDir()
+
+	td := utils.JumppadTemp()
 	os.WriteFile(fmt.Sprintf("%s/resource.exec.test.out", td), []byte("FOO=BAR"), 0644)
 	t.Cleanup(func() {
 		os.Remove(fmt.Sprintf("%s/resource.exec.test.out", td))
@@ -68,7 +70,7 @@ func TestDeletesOutput(t *testing.T) {
 	e.Script = "echo FOO=BAR >> $EXEC_OUTPUT"
 
 	// write the output for the test
-	td := os.TempDir()
+	td := utils.JumppadTemp()
 	os.WriteFile(fmt.Sprintf("%s/resource.exec.test.out", td), []byte("FOO=BAR"), 0644)
 
 	err := p.Create(context.Background())
@@ -85,7 +87,7 @@ func TestCopiesOutputInExec(t *testing.T) {
 	e.Script = "echo FOO=BAR >> $EXEC_OUTPUT"
 
 	// write the output for the test
-	td := os.TempDir()
+	td := utils.JumppadTemp()
 	os.WriteFile(fmt.Sprintf("%s/resource.exec.test.out", td), []byte("FOO=BAR"), 0644)
 	t.Cleanup(func() {
 		os.Remove(fmt.Sprintf("%s/resource.exec.test.out", td))

--- a/pkg/config/resources/exec/resource.go
+++ b/pkg/config/resources/exec/resource.go
@@ -35,7 +35,7 @@ type Exec struct {
 	// output
 	PID      int               `hcl:"pid,optional" json:"pid,omitempty"`             // PID stores the ID of the created connector service if it is a local exec
 	ExitCode int               `hcl:"exit_code,optional" json:"exit_code,omitempty"` // Exit code of the process
-	Output   map[string]string `hcl:"output,optional" json:"output,omitempty"`       // output values returned from Terraform
+	Output   map[string]string `hcl:"output,optional" json:"output,omitempty"`       // output values returned from exec
 }
 
 func (e *Exec) Process() error {

--- a/pkg/config/resources/exec/resource.go
+++ b/pkg/config/resources/exec/resource.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jumppad-labs/jumppad/pkg/config"
 	ctypes "github.com/jumppad-labs/jumppad/pkg/config/resources/container"
 	"github.com/jumppad-labs/jumppad/pkg/utils"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // TypeExec is the resource string for an Exec resource
@@ -34,9 +33,9 @@ type Exec struct {
 	RunAs    *ctypes.User               `hcl:"run_as,block" json:"run_as,omitempty"`    // User block for mapping the user id and group id inside the container
 
 	// output
-	PID      int       `hcl:"pid,optional" json:"pid,omitempty"`             // PID stores the ID of the created connector service if it is a local exec
-	ExitCode int       `hcl:"exit_code,optional" json:"exit_code,omitempty"` // Exit code of the process
-	Output   cty.Value `hcl:"output,optional"`                               // output values returned from Terraform
+	PID      int               `hcl:"pid,optional" json:"pid,omitempty"`             // PID stores the ID of the created connector service if it is a local exec
+	ExitCode int               `hcl:"exit_code,optional" json:"exit_code,omitempty"` // Exit code of the process
+	Output   map[string]string `hcl:"output,optional" json:"output,omitempty"`       // output values returned from Terraform
 }
 
 func (e *Exec) Process() error {
@@ -67,6 +66,7 @@ func (e *Exec) Process() error {
 			kstate := r.(*Exec)
 			e.PID = kstate.PID
 			e.ExitCode = kstate.ExitCode
+			e.Output = kstate.Output
 		}
 	}
 


### PR DESCRIPTION
## New Features:
Adds outputs for 'exec' resources

Exec resources now have a new parameter 'output' which is a map of key value pairs.
Values for output can be set by echoing a key value to the file '${EXEC_OUTPUT}' in 
the defined script for either remote or local exec.

```hcl
resource "exec" "install" {
  # Add the output
  echo "exec=install" >> $EXEC_OUTPUT
  echo "foo=bar" >> $EXEC_OUTPUT
  EOF

  timeout = "30s"
}

output "local_exec_install" {
  value = resource.exec.install.output.exec
}
```

Enable experimental support for nvidia GPUs for container resources

This feature configures the container to use the nvidia runtime and the nvidia
device plugin to access the GPU.  Currently this has only been tested with WSL2 and
Nvidia GPUs.

```hcl
resource "container" "gpu_test" {
  image {
    name = "nvcr.io/nvidia/k8s/cuda-sample:nbody"
  }

  command = ["nbody", "-gpu", "-benchmark"]

  resources {
    gpu {
      driver     = "nvidia"
      device_ids = ["0"]
    }
  }
}
```