### PR TITLE
Add error message when Dockerfile is outside context for build

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -683,8 +683,6 @@ github.com/jumppad-labs/go-cty v0.0.0-20230804061424-9e985cb751f6 h1:1ADItCWr5pr
 github.com/jumppad-labs/go-cty v0.0.0-20230804061424-9e985cb751f6/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/jumppad-labs/gohup v0.4.0 h1:0OplHvnKnOLkqWm417sRHLSiJ4xGeb8LiSSAJ51QrYg=
 github.com/jumppad-labs/gohup v0.4.0/go.mod h1:JYvZnemxJlWDyx8RbDNcCBLZSvIrYlYLnkQqR1BKFW4=
-github.com/jumppad-labs/hclconfig v0.22.1 h1:l+BYtDjK2kqDCfXMeGSjfMw2n0bqWFHuaPijlsqUxeU=
-github.com/jumppad-labs/hclconfig v0.22.1/go.mod h1:1S/JRGGwOHAUWIQN/4HoEDysW55fFMr2sfDPh0pIMqM=
 github.com/jumppad-labs/hclconfig v0.23.0 h1:kV5FsjTRSptRRQ9Sd5VaWRx3KvDSYw/6PsGm07wxFsI=
 github.com/jumppad-labs/hclconfig v0.23.0/go.mod h1:1S/JRGGwOHAUWIQN/4HoEDysW55fFMr2sfDPh0pIMqM=
 github.com/jumppad-labs/log v0.0.0-20230711151418-55bbc87954b7 h1:jxF+Sxei1/7c7tLcV3Juu+rCIAhBv2jdicokriFohYE=

--- a/pkg/config/resources/build/resource.go
+++ b/pkg/config/resources/build/resource.go
@@ -1,6 +1,10 @@
 package build
 
 import (
+	"fmt"
+	"os"
+	"path"
+
 	"github.com/jumppad-labs/hclconfig/types"
 	"github.com/jumppad-labs/jumppad/pkg/config"
 	"github.com/jumppad-labs/jumppad/pkg/config/resources/container"
@@ -47,6 +51,16 @@ type Output struct {
 
 func (b *Build) Process() error {
 	b.Container.Context = utils.EnsureAbsolute(b.Container.Context, b.Meta.File)
+
+	// check that the Dockerfile exists inside the context folder
+	// if not raise an error
+	if b.Container.DockerFile != "" {
+		path := path.Join(b.Container.Context, b.Container.DockerFile)
+		_, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("Dockerfile must located in the context folder, the file %s, does not exist in the context path %s", b.Container.DockerFile, b.Container.Context)
+		}
+	}
 
 	cfg, err := config.LoadState()
 	if err == nil {

--- a/pkg/config/resources/build/resource_test.go
+++ b/pkg/config/resources/build/resource_test.go
@@ -1,0 +1,39 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/jumppad-labs/hclconfig/types"
+	"github.com/jumppad-labs/jumppad/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	config.RegisterResource(TypeBuild, &Build{}, &Provider{})
+}
+
+func TestBuildRaisesErrorWhenDockerfileOutsideContext(t *testing.T) {
+	c := &Build{
+		ResourceBase: types.ResourceBase{Meta: types.Meta{File: "./"}},
+		Container: BuildContainer{
+			Context:    "../../../../examples/build/src",
+			DockerFile: "/Dockerfile/Dockerfile",
+		},
+	}
+
+	err := c.Process()
+	require.Error(t, err)
+}
+
+func TestBuildNoErrorWhenDockerfileInContext(t *testing.T) {
+	c := &Build{
+		ResourceBase: types.ResourceBase{Meta: types.Meta{File: "./"}},
+		Container: BuildContainer{
+			Context:    "../../../../examples/build/src",
+			DockerFile: "./Docker/Dockerfile",
+		},
+	}
+
+	err := c.Process()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds additional error message to inform the user when the Dockerfile is outside of the context folder.