### PR TITLE
Updated to use latest HCL config, and docker images

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -31,7 +31,7 @@ jobs:
           dagger-flags: "--progress=plain"
       
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: archives
           path: |
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Download-Binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: archives
           path: ./build_artifacts
@@ -124,7 +124,7 @@ jobs:
 
     steps:
       - name: Download-Binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: archives
           path: ./build_artifacts
@@ -174,7 +174,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download-Binaries
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: archives
           path: ./build_artifacts

--- a/Makefile
+++ b/Makefile
@@ -54,5 +54,8 @@ generate_mocks:
 
 install_local:
 	go build -ldflags "-X main.version=${git_commit}" -gcflags=all="-N -l" -o bin/jumppad main.go
-	sudo mv /usr/local/bin/jumppad /usr/local/bin/jumppad-old || true
-	sudo cp bin/jumppad /usr/local/bin/jumppad
+	sudo mv /usr/bin/jumppad /usr/bin/jumppad-old || true
+	sudo cp bin/jumppad /usr/bin/jumppad
+
+remove_local:
+	sudo mv /usr/bin/jumppad-old /usr/bin/jumppad || true

--- a/examples/build/test/build.feature
+++ b/examples/build/test/build.feature
@@ -14,7 +14,7 @@ Scenario: Build Image and Create Docker Container
   Then the following resources should be running
     | name                                       |
     | module.container.resource.container.app  |
-  And a HTTP call to "http://app.local.jumppad.dev:19090/" should result in status 200
+  And a HTTP call to "http://app.local.jmpd.in:19090/" should result in status 200
 
 Scenario: Build Image and Load to Nomad Cluster
   Given the following jumppad variables are set
@@ -27,7 +27,7 @@ Scenario: Build Image and Load to Nomad Cluster
   Then the following resources should be running
     | name                      |
     | module.nomad.resource.nomad_cluster.dev  |
-  And a HTTP call to "http://app.local.jumppad.dev:19090/" should result in status 200
+  And a HTTP call to "http://app.local.jmpd.in:19090/" should result in status 200
 
 Scenario: Build Image and Load to Kubernetes Cluster
   Given the following jumppad variables are set
@@ -40,4 +40,4 @@ Scenario: Build Image and Load to Kubernetes Cluster
   Then the following resources should be running
     | name                      |
     | module.kubernetes.resource.k8s_cluster.dev  |
-  And a HTTP call to "http://app.local.jumppad.dev:19090/" should result in status 200
+  And a HTTP call to "http://app.local.jmpd.in:19090/" should result in status 200

--- a/examples/container/container.hcl
+++ b/examples/container/container.hcl
@@ -112,6 +112,11 @@ resource "container" "consul" {
     memory = 1024
   }
 
+  port {
+    local  = 8507
+    remote = 8507
+  }
+
   port_range {
     range       = "8500-8502"
     enable_host = true
@@ -145,6 +150,10 @@ resource "sidecar" "envoy" {
 
   image {
     name = "envoyproxy/envoy:v${variable.envoy_version}"
+  }
+
+  environment = {
+    PORT = "${resource.container.consul.port.0.local}"
   }
 
   command = ["tail", "-f", "/dev/null"]

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/infinytum/raymond/v2 v2.0.5
 	github.com/jumppad-labs/connector v0.4.0
 	github.com/jumppad-labs/gohup v0.4.0
-	github.com/jumppad-labs/hclconfig v0.24.0
+	github.com/jumppad-labs/hclconfig v0.25.0
 	github.com/jumppad-labs/plugin-sdk v0.1.1-0.20240306185853-c09f71f81b8a
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -692,6 +692,8 @@ github.com/jumppad-labs/gohup v0.4.0 h1:0OplHvnKnOLkqWm417sRHLSiJ4xGeb8LiSSAJ51Q
 github.com/jumppad-labs/gohup v0.4.0/go.mod h1:JYvZnemxJlWDyx8RbDNcCBLZSvIrYlYLnkQqR1BKFW4=
 github.com/jumppad-labs/hclconfig v0.24.0 h1:SyMCl2rwLC5o32CCp50fsVbJxyFFCiYoMejvfh9RJKM=
 github.com/jumppad-labs/hclconfig v0.24.0/go.mod h1:AOzW0btnKiqUKYVi3ioGzSPNCWsTzsJxKcqzVORccvk=
+github.com/jumppad-labs/hclconfig v0.25.0 h1:CRIprG+i+Ol9s2izb6PRrt23kyGYZ1OC/XGFqdI1o/M=
+github.com/jumppad-labs/hclconfig v0.25.0/go.mod h1:AOzW0btnKiqUKYVi3ioGzSPNCWsTzsJxKcqzVORccvk=
 github.com/jumppad-labs/log v0.0.0-20240827082827-4404884e31a7 h1:tuoFYWXAqT5BheDlQNumY1DxvkW8bjG9JOzoxpFneZs=
 github.com/jumppad-labs/log v0.0.0-20240827082827-4404884e31a7/go.mod h1:S9jhxE2C1+jv2PlLTAow3h+ZILzvXRhd6eBjFAUcfgI=
 github.com/jumppad-labs/plugin-sdk v0.1.1-0.20240306185853-c09f71f81b8a h1:fqPvAO1o/6bUIm0fwEbXcUzUCng+GDlLmSMT/5oUJUE=

--- a/pkg/config/resources/k8s/provider_cluster.go
+++ b/pkg/config/resources/k8s/provider_cluster.go
@@ -419,7 +419,8 @@ func (p *ClusterProvider) createK3s(ctx context.Context) error {
 		"--kube-proxy-arg=conntrack-max-per-core=0",
 		disableArgs,
 		fmt.Sprintf("--snapshotter=%s", snapShotter),
-		fmt.Sprintf("--tls-san=%s", FQDN),
+		fmt.Sprintf("--tls-san=%s", FQDN),                // add the FQDN for the server
+		fmt.Sprintf("--tls-san=%s", utils.GetDockerIP()), // add the docker host IP
 		clusterToken,
 	}
 

--- a/pkg/config/resources/k8s/resource_cluster.go
+++ b/pkg/config/resources/k8s/resource_cluster.go
@@ -74,8 +74,8 @@ type KubeConfig struct {
 	ClientKey         string `hcl:"client_key" json:"client_key"`                 // base64 encoded client key
 }
 
-const k3sBaseImage = "shipyardrun/k3s"
-const k3sBaseVersion = "v1.27.4"
+const k3sBaseImage = "ghcr.io/jumppad-labs/kubernetes"
+const k3sBaseVersion = "v1.31.1"
 
 func (k *Cluster) Process() error {
 	if k.APIPort == 0 {

--- a/pkg/config/resources/nomad/resource_cluster.go
+++ b/pkg/config/resources/nomad/resource_cluster.go
@@ -61,8 +61,8 @@ type NomadCluster struct {
 	ExternalIP string `hcl:"external_ip,optional" json:"external_ip,omitempty"`
 }
 
-const nomadBaseImage = "shipyardrun/nomad"
-const nomadBaseVersion = "1.7.5"
+const nomadBaseImage = "ghcr.io/jumppad-labs/nomad"
+const nomadBaseVersion = "v1.8.4"
 
 type Config struct {
 	// Specifies configuration for the Docker driver.


### PR DESCRIPTION
Fixes issue when value was interpolated for the the first time using the following syntax:

```
VAR = "${resource.container.mine.port.0.value}"
```

There was a bug in HCL config that stopped the interpolation value being processed when it was directly included in a template.

Updates Nomad and K8s images to latest v1.31.1 and v1.8.4 respectively.