### PR TITLE
fix bug with health check method and set module cache

### DIFF
--- a/examples/single_file/container.hcl
+++ b/examples/single_file/container.hcl
@@ -73,6 +73,16 @@ resource "container" "consul" {
     destination = "/cache"
     type        = "volume"
   }
+
+  health_check {
+    timeout = "30s"
+
+    http {
+      address       = "http://localhost:8500/v1/status/leader"
+      success_codes = [200]
+      method        = "POST"
+    }
+  }
 }
 
 output "consul_addr" {

--- a/pkg/clients/http/http.go
+++ b/pkg/clients/http/http.go
@@ -55,7 +55,7 @@ func (h *HTTPImpl) HealthCheckHTTP(address, method string, headers map[string][]
 			return fmt.Errorf("timeout waiting for HTTP health check %s", address)
 		}
 
-		if method != "" {
+		if method == "" {
 			method = http.MethodGet
 		}
 

--- a/pkg/config/zz_hclparser.go
+++ b/pkg/config/zz_hclparser.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"path"
+
 	"github.com/jumppad-labs/hclconfig"
 	"github.com/jumppad-labs/hclconfig/types"
+	"github.com/jumppad-labs/jumppad/pkg/utils"
 	sdk "github.com/jumppad-labs/plugin-sdk"
 )
 
@@ -38,6 +41,7 @@ func NewParser(callback hclconfig.WalkCallback, variables map[string]string, var
 	cfg.VariableEnvPrefix = "JUMPPAD_VAR_"
 	cfg.Variables = variables
 	cfg.VariablesFiles = variablesFiles
+	cfg.ModuleCache = path.Join(utils.JumppadHome(), "modules")
 
 	p := hclconfig.NewParser(cfg)
 


### PR DESCRIPTION
This PR fixes an issue with Health checks that would ignore the HTTP method passed in the configuration.  Also changes the location of the module cache from the default `$HOME/.hclconfig/modules` to `$HOME/.jumppad/modules`.