### PR TITLE
Remove check for duplicate network names from Parse

### DIFF
--- a/pkg/config/resources/network/provider_test.go
+++ b/pkg/config/resources/network/provider_test.go
@@ -19,7 +19,7 @@ var bridgeNetwork = dtypes.NetworkResource{
 	ID:   "bridge",
 	Name: "bridge",
 	IPAM: network.IPAM{
-		Config: []network.IPAMConfig{network.IPAMConfig{Subnet: "10.8.2.0/24"}},
+		Config: []network.IPAMConfig{{Subnet: "10.8.2.0/24"}},
 	},
 }
 
@@ -45,10 +45,10 @@ func TestLookupReturnsID(t *testing.T) {
 	md, p := setupNetworkTests(t, c)
 	testutils.RemoveOn(&md.Mock, "NetworkList")
 	md.On("NetworkList", mock.Anything, mock.Anything).Return([]dtypes.NetworkResource{
-		dtypes.NetworkResource{
+		{
 			ID: "testnet",
 			IPAM: network.IPAM{
-				Config: []network.IPAMConfig{network.IPAMConfig{Subnet: "10.1.2.0/24"}},
+				Config: []network.IPAMConfig{{Subnet: "10.1.2.0/24"}},
 			},
 		},
 		bridgeNetwork,
@@ -128,10 +128,10 @@ func TestNetworkDoesNOTCreateWhenExists(t *testing.T) {
 	md, p := setupNetworkTests(t, c)
 	testutils.RemoveOn(&md.Mock, "NetworkList")
 	md.On("NetworkList", mock.Anything, mock.Anything).Return([]dtypes.NetworkResource{
-		dtypes.NetworkResource{
+		{
 			ID: "testnet",
 			IPAM: network.IPAM{
-				Config: []network.IPAMConfig{network.IPAMConfig{Subnet: "10.1.2.0/24"}},
+				Config: []network.IPAMConfig{{Subnet: "10.1.2.0/24"}},
 			},
 		}, bridgeNetwork,
 	}, nil)
@@ -150,10 +150,10 @@ func TestCreateWithCorrectNameAndDifferentSubnetReturnsError(t *testing.T) {
 	md, p := setupNetworkTests(t, c)
 	testutils.RemoveOn(&md.Mock, "NetworkList")
 	md.On("NetworkList", mock.Anything, mock.Anything).Return([]dtypes.NetworkResource{
-		dtypes.NetworkResource{
+		{
 			ID: "testnet",
 			IPAM: network.IPAM{
-				Config: []network.IPAMConfig{network.IPAMConfig{Subnet: "10.1.1.0/24"}},
+				Config: []network.IPAMConfig{{Subnet: "10.1.1.0/24"}},
 			},
 		}, bridgeNetwork,
 	}, nil)
@@ -171,10 +171,10 @@ func TestCreateWithOverlappingSubnetReturnsError(t *testing.T) {
 	md, p := setupNetworkTests(t, c)
 	testutils.RemoveOn(&md.Mock, "NetworkList")
 	md.On("NetworkList", mock.Anything, mock.Anything).Return([]dtypes.NetworkResource{
-		dtypes.NetworkResource{
+		{
 			ID: "abc",
 			IPAM: network.IPAM{
-				Config: []network.IPAMConfig{network.IPAMConfig{Subnet: "10.2.0.0/24"}},
+				Config: []network.IPAMConfig{{Subnet: "10.2.0.0/24"}},
 			},
 		}, bridgeNetwork,
 	}, nil)

--- a/pkg/config/resources/network/resource.go
+++ b/pkg/config/resources/network/resource.go
@@ -1,8 +1,6 @@
 package network
 
 import (
-	"fmt"
-
 	"github.com/jumppad-labs/hclconfig/types"
 )
 
@@ -16,24 +14,4 @@ type Network struct {
 
 	Subnet     string `hcl:"subnet" json:"subnet"`
 	EnableIPv6 bool   `hcl:"enable_ipv6,optional" json:"enable_ipv6"`
-}
-
-func (c *Network) Parse(conf types.Findable) error {
-	// do any other networks with this name exist?
-	nets, err := conf.FindResourcesByType(TypeNetwork)
-	if err != nil {
-		return err
-	}
-
-	for _, n := range nets {
-		if n.Metadata().Name == c.Meta.Name && n.Metadata().ID != c.Meta.ID {
-			return fmt.Errorf("a network named '%s' is already defined by the resource '%s'", c.Meta.Name, n.Metadata().ID)
-		}
-	}
-
-	return nil
-}
-
-func (c *Network) Process() error {
-	return nil
 }


### PR DESCRIPTION
This fixes #308 but delays feedback on duplicate network names to create time.

We should figure out a better way to do validation of resources, but that is a much bigger effort.
