### PR TITLE
Bump hclconfig to use the new v0.29.0 version of hclconfig

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -42,7 +42,7 @@ jobs:
         if: always()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          tile: ${{ github.job_id }}
+          title: ${{ github.job_id }}
           description: "Build application"
 
   functional_test_docker:
@@ -98,7 +98,7 @@ jobs:
         if: always()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          tile: ${{ github.job_id }}
+          title: ${{ github.job_id }}
           description: "Functional tests for docker: ${{matrix.folder}}"
 
   functional_test_podman:
@@ -152,7 +152,7 @@ jobs:
         if: always()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          tile: ${{ github.job_id }}
+          title: ${{ github.job_id }}
           description: "Functional tests for ${{matrix.folder}}"
   
   release:
@@ -228,6 +228,6 @@ jobs:
       uses: sarisia/actions-status-discord@v1
       if: always()
       with:
-        tile: ${{ github.job_id }}
+        title: ${{ github.job_id }}
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
         description: "Push new version ${{ needs.github_release.outputs.version }} to Winget"

--- a/examples/registries/build.hcl
+++ b/examples/registries/build.hcl
@@ -39,7 +39,7 @@ resource "container" "noauth" {
   }
 
   volume {
-    source      = data("certs")
+    source      = resource.certificate_leaf.registry.output
     destination = "/certs"
   }
 }
@@ -75,7 +75,7 @@ resource "container" "auth" {
   }
 
   volume {
-    source      = data("certs")
+    source      = resource.certificate_leaf.registry.output
     destination = "/certs"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/infinytum/raymond/v2 v2.0.5
 	github.com/jumppad-labs/connector v0.4.0
 	github.com/jumppad-labs/gohup v0.4.0
-	github.com/jumppad-labs/hclconfig v0.28.2-0.20250513065622-4556e0f28745
+	github.com/jumppad-labs/hclconfig v0.29.0
 	github.com/jumppad-labs/plugin-sdk v0.4.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mattn/go-isatty v0.0.20

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ module github.com/jumppad-labs/jumppad
 // https://github.com/docker/cli/issues/4437
 // fixed it by using docker v23.0.7-0.20230714215826-f00e7af96042+incompatible
 // switch to v24.0.4+incompatible once github actions updates their docker version
-go 1.23.0
-
-toolchain go1.23.5
+go 1.24.3
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -36,7 +34,7 @@ require (
 	github.com/infinytum/raymond/v2 v2.0.5
 	github.com/jumppad-labs/connector v0.4.0
 	github.com/jumppad-labs/gohup v0.4.0
-	github.com/jumppad-labs/hclconfig v0.28.0
+	github.com/jumppad-labs/hclconfig v0.28.2-0.20250513065622-4556e0f28745
 	github.com/jumppad-labs/plugin-sdk v0.4.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -1174,8 +1174,8 @@ github.com/jumppad-labs/go-cty v0.0.0-20230804061424-9e985cb751f6 h1:1ADItCWr5pr
 github.com/jumppad-labs/go-cty v0.0.0-20230804061424-9e985cb751f6/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/jumppad-labs/gohup v0.4.0 h1:0OplHvnKnOLkqWm417sRHLSiJ4xGeb8LiSSAJ51QrYg=
 github.com/jumppad-labs/gohup v0.4.0/go.mod h1:JYvZnemxJlWDyx8RbDNcCBLZSvIrYlYLnkQqR1BKFW4=
-github.com/jumppad-labs/hclconfig v0.28.2-0.20250513065622-4556e0f28745 h1:qpKlLIKrxhwZzShCCXIlfBxClXQhsVK1yZrF6HTCtYE=
-github.com/jumppad-labs/hclconfig v0.28.2-0.20250513065622-4556e0f28745/go.mod h1:UiDq9kWaSsw5MQp0iDej2oxvo0E+Xwx7UVuEDlzetnw=
+github.com/jumppad-labs/hclconfig v0.29.0 h1:ZJKsei7agJ8wEx+r0iZQsOKWYxWvN8Wldd5/897xBxk=
+github.com/jumppad-labs/hclconfig v0.29.0/go.mod h1:UiDq9kWaSsw5MQp0iDej2oxvo0E+Xwx7UVuEDlzetnw=
 github.com/jumppad-labs/log v0.0.0-20240827082827-4404884e31a7 h1:tuoFYWXAqT5BheDlQNumY1DxvkW8bjG9JOzoxpFneZs=
 github.com/jumppad-labs/log v0.0.0-20240827082827-4404884e31a7/go.mod h1:S9jhxE2C1+jv2PlLTAow3h+ZILzvXRhd6eBjFAUcfgI=
 github.com/jumppad-labs/plugin-sdk v0.4.0 h1:deNk7h8W+6dsxj2ADP63o07Dv313vcBI8C4d1aBUO/c=

--- a/go.sum
+++ b/go.sum
@@ -1174,10 +1174,8 @@ github.com/jumppad-labs/go-cty v0.0.0-20230804061424-9e985cb751f6 h1:1ADItCWr5pr
 github.com/jumppad-labs/go-cty v0.0.0-20230804061424-9e985cb751f6/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/jumppad-labs/gohup v0.4.0 h1:0OplHvnKnOLkqWm417sRHLSiJ4xGeb8LiSSAJ51QrYg=
 github.com/jumppad-labs/gohup v0.4.0/go.mod h1:JYvZnemxJlWDyx8RbDNcCBLZSvIrYlYLnkQqR1BKFW4=
-github.com/jumppad-labs/hclconfig v0.26.0 h1:Qg/tC2WlhKwoTW0acAY/vyUXHwCuyr4NmshKLS81How=
-github.com/jumppad-labs/hclconfig v0.26.0/go.mod h1:AOzW0btnKiqUKYVi3ioGzSPNCWsTzsJxKcqzVORccvk=
-github.com/jumppad-labs/hclconfig v0.28.0 h1:6V6dMrTufkLHgyFdtJHiEcDM5hp9ItVNDZf98wGpVKs=
-github.com/jumppad-labs/hclconfig v0.28.0/go.mod h1:mrKi8iCDAqLwmhbOa5k1K56R4+ctsVuYveQ/sMaWYio=
+github.com/jumppad-labs/hclconfig v0.28.2-0.20250513065622-4556e0f28745 h1:qpKlLIKrxhwZzShCCXIlfBxClXQhsVK1yZrF6HTCtYE=
+github.com/jumppad-labs/hclconfig v0.28.2-0.20250513065622-4556e0f28745/go.mod h1:UiDq9kWaSsw5MQp0iDej2oxvo0E+Xwx7UVuEDlzetnw=
 github.com/jumppad-labs/log v0.0.0-20240827082827-4404884e31a7 h1:tuoFYWXAqT5BheDlQNumY1DxvkW8bjG9JOzoxpFneZs=
 github.com/jumppad-labs/log v0.0.0-20240827082827-4404884e31a7/go.mod h1:S9jhxE2C1+jv2PlLTAow3h+ZILzvXRhd6eBjFAUcfgI=
 github.com/jumppad-labs/plugin-sdk v0.4.0 h1:deNk7h8W+6dsxj2ADP63o07Dv313vcBI8C4d1aBUO/c=
@@ -1536,8 +1534,6 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
-golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
-golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/crypto v0.34.0 h1:+/C6tk6rf/+t5DhUketUbD1aNGqiSX3j15Z6xuIDlBA=
 golang.org/x/crypto v0.34.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/clients/container/docker_tasks.go
+++ b/pkg/clients/container/docker_tasks.go
@@ -1529,7 +1529,7 @@ func copyDir(src string, dest string) error {
 		return err
 	}
 	if !file.IsDir() {
-		return fmt.Errorf("Source " + file.Name() + " is not a directory!")
+		return fmt.Errorf("source %s is not a directory", file.Name())
 	}
 
 	err = os.Mkdir(dest, 0755)

--- a/pkg/config/resources/exec/provider.go
+++ b/pkg/config/resources/exec/provider.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jumppad-labs/hclconfig/convert"
 	htypes "github.com/jumppad-labs/hclconfig/types"
 	"github.com/jumppad-labs/jumppad/pkg/clients"
 	cmdClient "github.com/jumppad-labs/jumppad/pkg/clients/command"
@@ -18,6 +19,7 @@ import (
 	"github.com/jumppad-labs/jumppad/pkg/clients/logger"
 	"github.com/jumppad-labs/jumppad/pkg/utils"
 	sdk "github.com/jumppad-labs/plugin-sdk"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // checks Provider implements the sdk.Provider interface
@@ -361,7 +363,17 @@ func (p *Provider) generateOutput() error {
 		output[parts[0]] = parts[1]
 	}
 
-	p.config.Output = output
+	values := map[string]cty.Value{}
+	for k, v := range output {
+		value, err := convert.GoToCtyValue(v)
+		if err != nil {
+			return fmt.Errorf("unable to convert output value to cty: %w", err)
+		}
+
+		values[k] = value
+	}
+
+	p.config.Output = cty.ObjectVal(values)
 
 	return nil
 }

--- a/pkg/config/resources/exec/provider_test.go
+++ b/pkg/config/resources/exec/provider_test.go
@@ -62,7 +62,7 @@ func TestParsesOutput(t *testing.T) {
 	err := p.Create(context.Background())
 	require.NoError(t, err)
 
-	require.True(t, e.Output["FOO"] == "BAR")
+	require.True(t, e.Output.AsValueMap()["FOO"].AsString() == "BAR")
 }
 
 func TestDeletesOutput(t *testing.T) {

--- a/pkg/config/resources/exec/resource.go
+++ b/pkg/config/resources/exec/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jumppad-labs/jumppad/pkg/config"
 	ctypes "github.com/jumppad-labs/jumppad/pkg/config/resources/container"
 	"github.com/jumppad-labs/jumppad/pkg/utils"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // TypeExec is the resource string for an Exec resource
@@ -33,10 +34,10 @@ type Exec struct {
 	RunAs    *ctypes.User               `hcl:"run_as,block" json:"run_as,omitempty"`    // User block for mapping the user id and group id inside the container
 
 	// output
-	PID      int               `hcl:"pid,optional" json:"pid,omitempty"`             // PID stores the ID of the created connector service if it is a local exec
-	ExitCode int               `hcl:"exit_code,optional" json:"exit_code,omitempty"` // Exit code of the process
-	Output   map[string]string `hcl:"output,optional" json:"output,omitempty"`       // output values returned from exec
-	Checksum string            `hcl:"checksum,optional" json:"checksum,omitempty"`   // Checksum of the script
+	PID      int       `hcl:"pid,optional" json:"pid,omitempty"`             // PID stores the ID of the created connector service if it is a local exec
+	ExitCode int       `hcl:"exit_code,optional" json:"exit_code,omitempty"` // Exit code of the process
+	Output   cty.Value `hcl:"output,optional" json:"output,omitempty"`       // output values returned from exec
+	Checksum string    `hcl:"checksum,optional" json:"checksum,omitempty"`   // Checksum of the script
 }
 
 func (e *Exec) Process() error {

--- a/pkg/config/resources/terraform/provider.go
+++ b/pkg/config/resources/terraform/provider.go
@@ -313,6 +313,8 @@ func (p *TerraformProvider) terraformApply(containerid string) error {
 	wd := path.Join("/config", p.config.WorkingDirectory)
 
 	script := `#!/bin/sh
+	set -e
+
   terraform init \
     -no-color
   terraform apply \
@@ -421,6 +423,8 @@ func (p *TerraformProvider) terraformDestroy(containerid string) error {
 	tfvarFlag := getTerraformVarsFlag(p.config)
 
 	script := `#!/bin/sh
+	set -e
+
   terraform init \
     -no-color
   terraform destroy \


### PR DESCRIPTION
- v0.29.0 improves validation
- fixed tests for registries
- updated exec to use cty.Value for outputs